### PR TITLE
Fix decorator/contextmanager usage with delay=True

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,47 @@ async def my_function():
 
 When delays are enabled, `asyncio.sleep` will be used instead of `time.sleep`.
 
+### Examples
+To prove that pyrate-limiter is working as expected, here is a complete example to demonstrate
+rate-limiting with delays:
+```python
+from time import perf_counter as time
+from pyrate_limiter import Duration, Limiter, RequestRate
+
+limiter = Limiter(RequestRate(5, Duration.SECOND))
+n_requests = 27
+
+@limiter.ratelimit("test", delay=True)
+def limited_function(start_time):
+    print(f"t + {(time() - start_time):.5f}")
+
+start_time = time()
+for _ in range(n_requests):
+    limited_function(start_time)
+print(f"Ran {n_requests} requests in {time() - start_time:.5f} seconds")
+```
+
+And an equivalent example for async usage:
+```python
+import asyncio
+from time import perf_counter as time
+from pyrate_limiter import Duration, Limiter, RequestRate
+
+limiter = Limiter(RequestRate(5, Duration.SECOND))
+n_requests = 27
+
+@limiter.ratelimit("test", delay=True)
+async def limited_function(start_time):
+    print(f"t + {(time() - start_time):.5f}")
+
+async def test_ratelimit():
+    start_time = time()
+    tasks = [limited_function(start_time) for _ in range(n_requests)]
+    await asyncio.gather(*tasks)
+    print(f"Ran {n_requests} requests in {time() - start_time:.5f} seconds")
+
+asyncio.run(test_ratelimit())
+```
 
 ### Spam-protection strategies
 - [x] Sometimes, we need a rate-limiter to protect our API from spamming/ddos attack. Some usual strategies for this could be as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyrate-limiter"
-version = "2.3.0"
+version = "2.3.1"
 description = "Python Rate-Limiter using Leaky-Bucket Algorimth Family"
 authors = ["vutr <me@vutr.io>"]
 license = "MIT"

--- a/pyrate_limiter/__init__.py
+++ b/pyrate_limiter/__init__.py
@@ -7,4 +7,4 @@ from .request_rate import *
 from .constants import *
 from .exceptions import *
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"

--- a/pyrate_limiter/limit_context_decorator.py
+++ b/pyrate_limiter/limit_context_decorator.py
@@ -70,18 +70,26 @@ class LimitContextDecorator:
         pass
 
     def delayed_acquire(self):
-        try:
-            self.try_acquire()
-        except BucketFullException as err:
-            delay_time = self.delay_or_reraise(err)
-            sleep(delay_time)
+        """Delay and retry until we can successfully acquire an available bucket item"""
+        while True:
+            try:
+                self.try_acquire()
+            except BucketFullException as err:
+                delay_time = self.delay_or_reraise(err)
+                sleep(delay_time)
+            else:
+                break
 
     async def async_delayed_acquire(self):
-        try:
-            self.try_acquire()
-        except BucketFullException as err:
-            delay_time = self.delay_or_reraise(err)
-            await asyncio.sleep(delay_time)
+        """Delay and retry until we can successfully acquire an available bucket item"""
+        while True:
+            try:
+                self.try_acquire()
+            except BucketFullException as err:
+                delay_time = self.delay_or_reraise(err)
+                await asyncio.sleep(delay_time)
+            else:
+                break
 
     def delay_or_reraise(self, err: BucketFullException) -> int:
         """Determine if we should delay after exceeding a rate limit. If so, return the delay time,


### PR DESCRIPTION
I found an issue with the decorator/contextmanager I previously added: after catching a `BucketFullException` and delaying, the delayed task will run without updating the bucket. This means the total delay time will be less than expected. For example, with 26 requests at 5 requests/second, the total delay time is ~4 seconds instead of 5. Same thing for non-concurrent async functions. For concurrent async functions, tasks won't get delayed correctly after the first delay.

The fix for this is to add a retry after the delay, until a task successfully acquires a bucket item. I updated the tests to check for this, and also added some more examples to the Readme.