### PR TITLE
Update test_sleep() to tolerate small differences in test execution time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,18 @@ before_install:
 install:
   - poetry install
 
-jobs:
-  include:
-    - stage: Check
-      script: poetry run cover
-    - stage: Publish
-      if: branch = master
-      script: skip
-      before_deploy:
-        - poetry config http-basic.pypi $PYPI_USERNAME $PYPI_PASSWORD
-        - poetry build -f sdist
-      deploy:
-        provider: script
-        script: poetry publish
-        skip_cleanup: true
+# Run tests for all python versions
+script:
+  - poetry run cover
+
+# Publish package only for master branch
+before_deploy:
+  - poetry config http-basic.pypi $PYPI_USERNAME $PYPI_PASSWORD
+  - poetry build -f sdist
+deploy:
+  provider: script
+  script: poetry publish
+  skip_cleanup: true
+  on:
+    branch: master
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 dist: xenial
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 
 branches:
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.3.5] - 2021-09-22
 ### Added
+* Use `time.monotonic()` instead of `time.time()`
 * Support for floating point rate-limiting delays (more granular than 1 second)
 
 ## [2.3.4] - 2021-06-01

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 The request rate limiter using Leaky-bucket algorithm
 
 [![PyPI version](https://badge.fury.io/py/pyrate-limiter.svg)](https://badge.fury.io/py/pyrate-limiter)
+[![PyPI - Python Versions](https://img.shields.io/pypi/pyversions/pyrate-limiter)](https://pypi.org/project/pyrate-limiter)
 [![Coverage Status](https://coveralls.io/repos/github/vutran1710/PyrateLimiter/badge.svg?branch=master)](https://coveralls.io/github/vutran1710/PyrateLimiter?branch=master)
-[![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
-[![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/vutran1710/PyrateLimiter/graphs/commit-activity)
 [![PyPI license](https://img.shields.io/pypi/l/ansicolortags.svg)](https://pypi.python.org/pypi/pyrate-limiter/)
 [![HitCount](http://hits.dwyl.io/vutran1710/PyrateLimiter.svg)](http://hits.dwyl.io/vutran1710/PyrateLimiter)


### PR DESCRIPTION
* Updates #40 to fix failing test
* Add all supported python versions to Travis CI build matrix
    * It would be a good idea to make sure behavior is consistent across different python versions.
    * Use plain build `script`/`deploy` without build stages, since there's nothing to run in parallel
    * Running the tests multiple times will also help expose any other flaky tests (that might fail due to small differences in execution time).
    * use `on: branch` syntax to instead of `script: skip` to deploy only for master branch
* Update badge on Readme to include all supported python versions (via PyPI metadata)
* Update the test comments and output with a bit more info. Example output:
```python
pytest -s -vvv tests/test_01.py::test_sleep                                                                          

[00.0000] Pushed: 1 items
[00.5006] Pushed: 2 items
[01.0013] Pushed: 3 items
[01.5019] Pushed: 4 items
[02.0025] Pushed: 5 items
[02.5032] Pushed: 6 items
{'error': 'Bucket for test with Rate 6/5 is already full', 'identity': 'test', 'rate': '6/5', 'remaining_time': 1.9962562840009923}
[05.0023] Pushed: 8 items
[05.5029] Pushed: 9 items
[06.0035] Pushed: 10 items
[06.5042] Pushed: 11 items
[07.0048] Pushed: 12 items
[07.5054] Pushed: 13 items
{'error': 'Bucket for test with Rate 6/5 is already full', 'identity': 'test', 'rate': '6/5', 'remaining_time': 1.996202890004497}
[10.0044] Pushed: 15 items
Elapsed: 10.5050 seconds
```