### PR TITLE
Fix deploy stage: Run in a separate stage, after tests for all python versions have passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,6 @@ python:
   - "3.8"
   - "3.9"
 
-branches:
-  only:
-  - master
-  - release
-
-stages:
-  - Check
-  - Publish
-
 before_install:
   - pip install poetry
 
@@ -25,14 +16,17 @@ install:
 script:
   - poetry run cover
 
-# Publish package only for master branch
-before_deploy:
-  - poetry config http-basic.pypi $PYPI_USERNAME $PYPI_PASSWORD
-  - poetry build -f sdist
-deploy:
-  provider: script
-  script: poetry publish
-  skip_cleanup: true
-  on:
-    branch: master
-
+# Publish package only for master branch, after all tests have passed
+jobs:
+  include:
+    - stage: deploy
+      python: 3.9
+      script: skip
+      before_deploy:
+        - poetry config http-basic.pypi $PYPI_USERNAME $PYPI_PASSWORD
+        - poetry build -f sdist
+      deploy:
+        provider: script
+        script: poetry publish
+        on:
+          branch: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.3.6] - 2021-09-23
+* Run CI tests for all supported python versions
+* Fix issue with deployments on Travis CI
+
 ## [2.3.5] - 2021-09-22
 ### Added
 * Use `time.monotonic()` instead of `time.time()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyrate-limiter"
-version = "2.3.5"
+version = "2.3.6"
 description = "Python Rate-Limiter using Leaky-Bucket Algorimth Family"
 authors = ["vutr <me@vutr.io>"]
 license = "MIT"


### PR DESCRIPTION
This reverts some of the config changes in #42, which added a build matrix but accidentally applied it to `deploy` instead of just `test`.