### PR TITLE
Add 'skip_cleanup: true' to not delete build artifacts before publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ jobs:
         script: poetry publish
         on:
           branch: master
+        skip_cleanup: true


### PR DESCRIPTION
Attempt number 3... The deploy failed with:
```
No files to publish. Run poetry build first or use the --build option.
```
I guess Travis deletes build artifacts between `before_deploy` and `deploy` unless you tell it `skip_cleanup: true`... Which I see you had already added, and I mistakenly removed it in #42. Sorry!