### PR TITLE
Make SQLite bucket thread-safe and multiprocess-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.6.2] - 2022-03-30
+## [2.6.3] - TBD
+### Fixed
+* Make SQLite bucket thread-safe and multiprocess-safe
 
+## [2.6.2] - 2022-03-30
 ### Fixed
 * Remove development scripts from package published on PyPI
 
@@ -16,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 * Replace all formatting/linting tools with *pre-commit*
 
-## [2.6.0] - TBD
+## [2.6.0] - 2021-12-08
 ### Added
 * SQLite bucket backend
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,6 +4,9 @@ from nox_poetry import session
 # Reuse virtualenv created by poetry instead of creating new ones
 nox.options.reuse_existing_virtualenvs = True
 
+PYTEST_ARGS = ["--verbose", "-s", "--full-trace", "--maxfail=1", "--numprocesses=auto"]
+COVERAGE_ARGS = ["--cov", "--cov-report=term", "--cov-report=xml"]
+
 
 @session(python=False)
 def lint(session) -> None:
@@ -13,16 +16,9 @@ def lint(session) -> None:
 @session(python=False)
 def cover(session) -> None:
     """Run tests and generate coverage reports in both terminal output and XML (for Codecov)"""
-    session.run("pytest", "--maxfail=1", "--numprocesses=auto", "--cov", "--cov-report=term", "--cov-report=xml")
+    session.run("pytest", *PYTEST_ARGS, *COVERAGE_ARGS)
 
 
 @session(python=False)
 def test(session) -> None:
-    session.run(
-        "pytest",
-        "--maxfail=1",
-        "--verbose",
-        "-s",
-        "--fulltrace",
-        "--numprocesses=auto",
-    )
+    session.run("pytest", *PYTEST_ARGS)

--- a/pyrate_limiter/bucket.py
+++ b/pyrate_limiter/bucket.py
@@ -46,7 +46,11 @@ class AbstractBucket(ABC):
         """Return a list as copies of all items in the bucket"""
 
     def inspect_expired_items(self, time: float) -> Tuple[int, float]:
-        """Find how many items in bucket that have slipped out of the time-window"""
+        """Find how many items in bucket that have slipped out of the time-window
+
+        Returns:
+            The number of unexpired items, and the time until the next item will expire
+        """
         volume = self.size()
         item_count, remaining_time = 0, 0.0
 
@@ -57,6 +61,12 @@ class AbstractBucket(ABC):
                 break
 
         return item_count, remaining_time
+
+    def lock_acquire(self):
+        """Acquire a lock prior to beginning a new transaction, if needed"""
+
+    def lock_release(self):
+        """Release lock following a transaction, if needed"""
 
 
 class MemoryQueueBucket(AbstractBucket):

--- a/pyrate_limiter/limit_context_decorator.py
+++ b/pyrate_limiter/limit_context_decorator.py
@@ -97,7 +97,7 @@ class LimitContextDecorator:
         """
         delay_time = err.meta_info["remaining_time"]
         logger.debug(err.meta_info)
-        logger.info("Rate limit reached; % seconds remaining before next request", delay_time)
+        logger.info(f"Rate limit reached; {delay_time:.5f} seconds remaining before next request")
         exceeded_max_delay = bool(self.max_delay) and (delay_time > self.max_delay)
         if self.delay and not exceeded_max_delay:
             return delay_time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
 from datetime import datetime
-from logging import getLogger
+from logging import basicConfig
 from time import monotonic
 from time import time
 
 import pytest
 
 # Make log messages visible on test failure (or with pytest -s)
-getLogger("pyrate_limiter").setLevel("DEBUG")
+basicConfig(level="INFO")
+# Uncomment for more verbose output:
+# getLogger("pyrate_limiter").setLevel("DEBUG")
 
 
 @pytest.fixture(

--- a/tests/test_01.py
+++ b/tests/test_01.py
@@ -17,7 +17,7 @@ from pyrate_limiter import RequestRate
 
 def test_sleep(time_function):
     """Make requests at a rate of 6 requests per 5 seconds (avg. 1.2 requests per second).
-    If each request takes ~0.5 seconds, then the bucket should be full after 6 requests.
+    If each request takes ~0.5 seconds, then the bucket should be full after 6 requests (3 seconds).
     Run 15 requests, and expect a total of 2 delays required to stay within the rate limit.
     """
     rate = RequestRate(6, 5 * Duration.SECOND)
@@ -29,7 +29,7 @@ def test_sleep(time_function):
         try:
             limiter.try_acquire("test")
             print(f"[{time() - start:07.4f}] Pushed: {i+1} items")
-            sleep(0.5)
+            sleep(0.5)  # Simulated request rate
         except BucketFullException as err:
             print(err.meta_info)
             track_sleep(err.meta_info["remaining_time"])

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,65 @@
+"""Multithreaded and multiprocess stress tests"""
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from logging import getLogger
+from os.path import join
+from tempfile import gettempdir
+from time import perf_counter
+from time import sleep
+
+import pytest
+
+from pyrate_limiter import Duration
+from pyrate_limiter import Limiter
+from pyrate_limiter import RequestRate
+from pyrate_limiter import SQLiteBucket
+
+N_BUCKETS = 5  # Number of buckets to use
+N_REQUESTS = 101  # Total number of requests to make
+N_WORKERS = 7  # Number of parallel workers to use
+LIMIT_REQUESTS_PER_SECOND = 10  # Rate limit
+THREAD_REQUESTS_PER_SECOND = 7  # Attempted request rate per thread/process
+
+logger = getLogger("pyrate_limiter.tests")
+
+
+# TODO: These tests could potentially be run for all bucket classes
+# @pytest.mark.parametrize("bucket_class", [SQLiteBucket, MemoryListBucket, MemoryQueueBucket, RedisBucket])
+@pytest.mark.parametrize("bucket_class", [SQLiteBucket])
+@pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, ProcessPoolExecutor])
+def test_concurrency(executor_class, bucket_class):
+    """Make a fixed number of concurrent requests and check the total time they take to run"""
+    logger.info(f"Testing {bucket_class.__name__} with {executor_class.__name__}")
+
+    # Set up limiter and request function
+    path = join(gettempdir(), f"test_{executor_class.__name__}.sqlite")
+    rate = RequestRate(LIMIT_REQUESTS_PER_SECOND, Duration.SECOND)
+    limiter = Limiter(rate, bucket_class=bucket_class, bucket_kwargs={"path": path})
+    bucket_ids = [f"{executor_class}_bucket_{i}" for i in range(N_BUCKETS)]
+    start_time = perf_counter()
+    request_func = partial(_send_request, limiter, bucket_ids, start_time)
+
+    # Distribute requests across workers
+    with executor_class(max_workers=N_WORKERS) as executor:
+        list(executor.map(request_func, range(N_REQUESTS), timeout=300))
+
+    # Check total time, with debug logging
+    elapsed = perf_counter() - start_time
+    expected_min_time = (N_REQUESTS - 1) / LIMIT_REQUESTS_PER_SECOND
+    worker_type = "threads" if executor_class is ThreadPoolExecutor else "processes"
+    logger.info(
+        f"Ran {N_REQUESTS} requests with {N_WORKERS} {worker_type} in {elapsed:.2f} seconds\n"
+        f"With a rate limit of {LIMIT_REQUESTS_PER_SECOND}/second, expected at least "
+        f"{expected_min_time} seconds"
+    )
+    assert elapsed >= expected_min_time
+
+
+def _send_request(limiter, bucket_ids, start_time, n_request):
+    """Rate-limited test function. Defined in module scope so it can be serialized to multiple
+    processes.
+    """
+    with limiter.ratelimit(*bucket_ids, delay=True):
+        logger.info(f"t + {(perf_counter() - start_time):.5f}: Request {n_request+1}")
+        sleep(1 / THREAD_REQUESTS_PER_SECOND)

--- a/tests/test_context_decorator.py
+++ b/tests/test_context_decorator.py
@@ -4,7 +4,6 @@
 * No delay + delay + delay w/ max_delay
 """
 import asyncio
-from logging import getLogger
 from time import sleep
 from time import time
 from uuid import uuid4
@@ -15,9 +14,6 @@ from pyrate_limiter import BucketFullException
 from pyrate_limiter import Duration
 from pyrate_limiter import Limiter
 from pyrate_limiter import RequestRate
-
-# Make log messages visible on test failure (or with pytest -s)
-getLogger("pyrate_limiter").setLevel("DEBUG")
 
 
 def test_ratelimit__synchronous(time_function):

--- a/tests/test_sqlite_bucket.py
+++ b/tests/test_sqlite_bucket.py
@@ -1,12 +1,10 @@
-# TODO: This could be turned into either a test class or parametrized tests
-# to run for all bucket classes
 from sqlite3 import ProgrammingError
 from tempfile import gettempdir
 from time import time
 
 import pytest
 
-from pyrate_limiter.sqlite_bucket import SQLiteBucket
+from pyrate_limiter import SQLiteBucket
 
 
 def get_test_bucket():
@@ -84,4 +82,5 @@ def test_inspect_expired_items():
     # Expect 10 expired items within a time window starting 10 seconds ago
     item_count, remaining_time = bucket.inspect_expired_items(current_time - 10)
     assert item_count == 10
+    # Expect 1 second until the next item expires
     assert remaining_time == 1.0


### PR DESCRIPTION
Fixes #60 

* Add a lock around SQLite bucket operations for thread safety
    * We originally discussed using exclusive transactions, but per-bucket locking seems to work better.
    * Only the bucket(s) being processed for a given call of `try_aquire()` will be locked.
    * `isolation_level="EXCLUSIVE"` locks the entire database, but a per-bucket lock allows any other buckets to be safely be processed in parallel.
* Keep SQLite bucket size in memory after it's queried once, to avoid unnecessary reads
* Sort identities when locking/unlocking buckets, so the order is consistent. This avoids deadlock even if user does something like:
     * Thread 1: `try_acquire('id_1', 'id_2')`
     * Thread 2: `try_acquire('id_2', 'id_1')`
* Add a `lock_acquire()` and `lock_release()` method to `AbstractBucket`, since this needs to be called from `Limiter`
    * Currently only implemented by `SQLiteBucket`, but this could potentially apply to other future backends.
* Add tests for both multithreaded and multiprocess usage. These could potentially be run for other bucket backends, if needed.