### PR TITLE
Add a new SQLiteBucket subclass that uses py-filelock

### DIFF
--- a/.github/workflows/poetry-package.yml
+++ b/.github/workflows/poetry-package.yml
@@ -39,7 +39,7 @@ jobs:
         key: venv-${{ matrix.python-version }}-latest-${{ hashFiles('poetry.lock') }}
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: poetry install -v
+      run: poetry install -v -E all
 
     # Run linting, tests, and coverage
     - name: Lint
@@ -72,10 +72,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: snok/install-poetry@v1.3
+      with:
+        virtualenvs-in-project: true
     - name: Install dependencies
-      run: |
-        python -m pip install poetry
-        poetry install
+      run: poetry install -v -E all
     - name: Publish
       run: |
         poetry config http-basic.pypi ${{ secrets.PYPI_USERNAME }} ${{ secrets.PYPI_PASSWORD }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     rev: v0.930
     hooks:
     -   id: mypy
+        additional_dependencies: [types-filelock]
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.6.3] - TBD
+## [2.7.0] - TBD
+### Added
+* Add `FileLockSQliteBucket` for a SQLite backend with file-based locking
+
+## [2.6.3] - 2022-04-05
 ### Fixed
 * Make SQLite bucket thread-safe and multiprocess-safe
 
@@ -21,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.6.0] - 2021-12-08
 ### Added
-* SQLite bucket backend
+* Add `SQliteBucket` to persist rate limit data in a SQLite database
 
 ## [2.5.0] - 2021-12-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.7.0] - TBD
 ### Added
 * Add `FileLockSQliteBucket` for a SQLite backend with file-based locking
+* Add optional backend dependencies to package metadata
 
 ## [2.6.3] - 2022-04-05
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -72,10 +72,28 @@ the `path` argument to use a different location:
 ```python
 from pyrate_limiter import Limiter, SQLiteBucket
 
+limiter = Limiter(bucket_class=SQLiteBucket)
+```
+
+By default, the database will be stored in the system temp directory. You can specify a different
+path via `bucket_kwargs`:
+```python
 limiter = Limiter(
     bucket_class=SQLiteBucket,
-    bucket_kwargs={'path': '/tmp/pyrate_limiter.sqlite'},
+    bucket_kwargs={'path': '/path/to/db.sqlite'},
 )
+```
+
+#### Concurrency
+This backend is thread-safe, and may also be used with multiple child processes that share the same
+`Limiter` object, e.g. if created with `ProcessPoolExecutor` or `multiprocessing.Process`.
+
+If you want to use SQLite with multiple processes with no shared state, for example if created by
+running multiple scripts or by an external process, some additional protections are needed. For
+these cases, a separate `FileLockSQLiteBucket` class is available. This requires installing the
+[py-filelock](https://py-filelock.readthedocs.io) library.
+```python
+limiter = Limiter(bucket_class=FileLockSQLiteBucket)
 ```
 
 ### Redis

--- a/README.md
+++ b/README.md
@@ -338,9 +338,9 @@ requires the capability to `switch` the strategies instantly without re-deployin
 ### Setup & Commands
 - To setup local development,  *Poetry* and *Python 3.6* is required. Python can be installed using *Pyenv* or normal installation from binary source. To install *poetry*, follow the official guideline (https://python-poetry.org/docs/#installation).
 
-Then, in the repository directory...
+Then, in the repository directory, run the following to install all optional backend dependencies and dev dependencies:
 ```shell
-$ poetry install
+$ poetry install -E all
 ```
 
 Some shortcuts are included for some common development tasks, using [nox](https://nox.thea.codes):

--- a/poetry.lock
+++ b/poetry.lock
@@ -165,7 +165,7 @@ lua = ["lupa"]
 name = "filelock"
 version = "3.4.1"
 description = "A platform independent file lock."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -500,7 +500,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 name = "redis"
 version = "3.5.3"
 description = "Python client for Redis key-value store"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -511,8 +511,8 @@ hiredis = ["hiredis (>=0.1.3)"]
 name = "redis-py-cluster"
 version = "2.1.3"
 description = "Library for communicating with Redis Clusters. Built on top of redis-py lib"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4"
 
 [package.dependencies]
@@ -601,10 +601,13 @@ python-versions = ">=3.6"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
+[extras]
+all = ["filelock", "redis", "redis-py-cluster"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "5243419fc0e802bb306515aad000d450a24011e9a688f88a05303e6e1c457dfd"
+content-hash = "338d4a7c1e4b7bd398b52d97f71c40b23dc458682560c00e4edca2338c2c89e7"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,24 +20,29 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.6.2"
 
+# Optional backend dependencies
+filelock = {optional=true, version=">=3.0"}
+redis = {optional=true, version="^3.3"}
+redis-py-cluster = {optional=true, version="^2.1.3"}
+
+[tool.poetry.extras]
+all = ["filelock", "redis", "redis-py-cluster"]
+
 [tool.poetry.dev-dependencies]
-pytest-asyncio = "^0.12"
-logzero = "^1.5"
-redis = "^3.3"
-fakeredis = "^1.1.0"
 coverage = "^5.5"
-flake8_polyfill = "^1.0.2"
-filelock = ">=3.0"
-PyYAML = "^5.4.1"
-redis-py-cluster = "^2.1.3"
-django-redis = "^5.0.0"
 Django = "^3.2.8"
-pre-commit = "^2.17.0"
-pytest = "^6.2"
-pytest-cov = "^3.0"
+django-redis = "^5.0.0"
+fakeredis = "^1.1.0"
+flake8_polyfill = "^1.0.2"
+logzero = "^1.5"
 nox = "^2022.1.7"
 nox-poetry = ">=0.8"
+pre-commit = "^2.17.0"
+pytest = "^6.2"
+pytest-asyncio = "^0.12"
+pytest-cov = "^3.0"
 pytest-xdist = "^2.5.0"
+PyYAML = "^5.4.1"
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyrate-limiter"
-version = "2.6.3"
+version = "2.7.0"
 description = "Python Rate-Limiter using Leaky-Bucket Algorimth Family"
 authors = ["vutr <me@vutr.io>"]
 license = "MIT"
@@ -27,6 +27,7 @@ redis = "^3.3"
 fakeredis = "^1.1.0"
 coverage = "^5.5"
 flake8_polyfill = "^1.0.2"
+filelock = ">=3.0"
 PyYAML = "^5.4.1"
 redis-py-cluster = "^2.1.3"
 django-redis = "^5.0.0"
@@ -44,6 +45,11 @@ line-length = 120
 [tool.coverage.run]
 branch = true
 source = ['pyrate_limiter']
+
+[tool.coverage.report]
+exclude_lines = [
+    "except ImportError:",  # Not testing missing optional dependencies
+]
 
 [tool.coverage.xml]
 output = 'test-reports/coverage.xml'

--- a/pyrate_limiter/limit_context_decorator.py
+++ b/pyrate_limiter/limit_context_decorator.py
@@ -96,8 +96,7 @@ class LimitContextDecorator:
         otherwise re-raise the exception.
         """
         delay_time = err.meta_info["remaining_time"]
-        logger.debug(err.meta_info)
-        logger.info(f"Rate limit reached; {delay_time:.5f} seconds remaining before next request")
+        logger.debug(f"Rate limit reached; {delay_time:.5f} seconds remaining before next request")
         exceeded_max_delay = bool(self.max_delay) and (delay_time > self.max_delay)
         if self.delay and not exceeded_max_delay:
             return delay_time

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -3,6 +3,7 @@ from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from logging import getLogger
+from multiprocessing import Process
 from os.path import join
 from tempfile import gettempdir
 from time import perf_counter
@@ -11,6 +12,7 @@ from time import sleep
 import pytest
 
 from pyrate_limiter import Duration
+from pyrate_limiter import FileLockSQLiteBucket
 from pyrate_limiter import Limiter
 from pyrate_limiter import RequestRate
 from pyrate_limiter import SQLiteBucket
@@ -19,24 +21,34 @@ N_BUCKETS = 5  # Number of buckets to use
 N_REQUESTS = 101  # Total number of requests to make
 N_WORKERS = 7  # Number of parallel workers to use
 LIMIT_REQUESTS_PER_SECOND = 10  # Rate limit
-THREAD_REQUESTS_PER_SECOND = 7  # Attempted request rate per thread/process
+ATTEMPT_REQUESTS_PER_SECOND = 7  # Attempted request rate per thread/process
+TEST_DURATION = 30  # Time in seconds for filelock test to run
 
 logger = getLogger("pyrate_limiter.tests")
 
 
-# TODO: These tests could potentially be run for all bucket classes
+# TODO: This test could potentially be run for all bucket classes
 # @pytest.mark.parametrize("bucket_class", [SQLiteBucket, MemoryListBucket, MemoryQueueBucket, RedisBucket])
 @pytest.mark.parametrize("bucket_class", [SQLiteBucket])
 @pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, ProcessPoolExecutor])
 def test_concurrency(executor_class, bucket_class):
-    """Make a fixed number of concurrent requests and check the total time they take to run"""
+    """Make a fixed number of concurrent requests using a shared Limiter, and check the total time
+    they take to run
+    """
     logger.info(f"Testing {bucket_class.__name__} with {executor_class.__name__}")
 
-    # Set up limiter and request function
-    path = join(gettempdir(), f"test_{executor_class.__name__}.sqlite")
-    rate = RequestRate(LIMIT_REQUESTS_PER_SECOND, Duration.SECOND)
-    limiter = Limiter(rate, bucket_class=bucket_class, bucket_kwargs={"path": path})
-    bucket_ids = [f"{executor_class}_bucket_{i}" for i in range(N_BUCKETS)]
+    # Set up limiter
+    bucket_kwargs = {
+        "path": join(gettempdir(), f"test_{executor_class.__name__}.sqlite"),
+    }
+    limiter = Limiter(
+        RequestRate(LIMIT_REQUESTS_PER_SECOND, Duration.SECOND),
+        bucket_class=bucket_class,
+        bucket_kwargs=bucket_kwargs,
+    )
+
+    # Set up request function
+    bucket_ids = [f"{executor_class.__name__}_bucket_{i}" for i in range(N_BUCKETS)]
     start_time = perf_counter()
     request_func = partial(_send_request, limiter, bucket_ids, start_time)
 
@@ -57,9 +69,50 @@ def test_concurrency(executor_class, bucket_class):
 
 
 def _send_request(limiter, bucket_ids, start_time, n_request):
-    """Rate-limited test function. Defined in module scope so it can be serialized to multiple
-    processes.
+    """Rate-limited test function to send a single request, using a shared Limiter.
+    Defined in module scope so it can be serialized to multiple processes.
     """
     with limiter.ratelimit(*bucket_ids, delay=True):
-        logger.info(f"t + {(perf_counter() - start_time):.5f}: Request {n_request+1}")
-        sleep(1 / THREAD_REQUESTS_PER_SECOND)
+        logger.debug(f"t + {(perf_counter() - start_time):.5f}: Request {n_request+1}")
+        sleep(1 / ATTEMPT_REQUESTS_PER_SECOND)
+
+
+def test_filelock_concurrency():
+    """Continuously send requests using multiple processes, with a separate Limiter per process, but
+    a shared SQLite database. Runs for a fixed length of time, and checks the total number of
+    requests made.
+    """
+    start_time = perf_counter()
+    end_time = start_time + TEST_DURATION
+    db_path = join(gettempdir(), "test_FileLockSQLiteBucket.sqlite")
+    procs = []
+    request_counters = [1] * N_WORKERS  # Mutable counters to check results after processes complete
+
+    for i in range(N_WORKERS):
+        proc = Process(
+            target=_send_requests,
+            args=(start_time, end_time, db_path, i, request_counters[i]),
+        )
+        proc.start()
+        procs.append(proc)
+
+    for proc in procs:
+        proc.join()
+
+    expected_max_requests = LIMIT_REQUESTS_PER_SECOND * TEST_DURATION
+    assert sum(request_counters) <= expected_max_requests
+
+
+def _send_requests(start_time: float, end_time: float, db_path: str, n_process: int, n_requests: int):
+    """Send several rate-limited requests, with a separate Limiter per process."""
+    limiter = Limiter(
+        RequestRate(LIMIT_REQUESTS_PER_SECOND, Duration.SECOND),
+        bucket_class=FileLockSQLiteBucket,
+        bucket_kwargs={"path": db_path},
+    )
+    bucket_ids = [f"bucket_{i}" for i in range(N_BUCKETS)]
+
+    while perf_counter() < end_time:
+        with limiter.ratelimit(*bucket_ids, delay=True):
+            logger.debug(f"[Process {n_process}] t + {(perf_counter() - start_time):.5f}: Request {n_requests}")
+            n_requests += 1

--- a/tests/test_sqlite_bucket.py
+++ b/tests/test_sqlite_bucket.py
@@ -13,8 +13,8 @@ def get_test_bucket():
 
 def test_init():
     # The system temp directory should be used unless a path is provided
-    assert SQLiteBucket(identity="id").path.startswith(gettempdir())
-    assert SQLiteBucket(identity="id", path="bucket.db").path == "bucket.db"
+    assert str(SQLiteBucket(identity="id")._path).startswith(gettempdir())
+    assert str(SQLiteBucket(identity="id", path="bucket.db")._path) == "bucket.db"
 
     # The table name should be hashed
     assert SQLiteBucket(identity="id").table == "ratelimit_87ea5dfc8b8e384d848979496e706390b497e547"


### PR DESCRIPTION
Fixes #67 and #60

The changes in #61 made `SQLiteBucket` safe to use with multiple threads, and multiple processes with a shared `Limiter`.

However, to work with multiple processes _without_ a shared `Limiter`, a different means of inter-process communication is needed. A file lock seems to be the best way to do this. This does reduce performance, and also requires an extra dependency, so I'm making a separate bucket class for this.

# Changes
* Added `FileLockSQLiteBucket`
* Added a test using multiple processes without a shared `Limiter`
* Bumped `LimitContextDecorator` log messages down to debug, as it gets a bit spammy during the longer tests (with `pytest -v -s`)
* Added backend dependencies as optional extras in `poetry.dependencies` and `poetry.extras`
    * This does not cause these these dependencies to be installed by default, but adds them to package metadata
    * Also makes them installable via `poetry install -E all` or `pip install pyrate-limiter[all]`