### PR TITLE
Doc/test update: Recommend `FileLockSQLiteBucket` for all usage with SQLite + multiprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,11 +267,9 @@ limiter = Limiter(
 ```
 
 #### Concurrency
-This backend is thread-safe, and may also be used with multiple child processes that share the same
-`Limiter` object, e.g. if created with `ProcessPoolExecutor` or `multiprocessing.Process`.
+This backend is thread-safe.
 
-If you want to use SQLite with multiple processes with no shared state, for example if created by
-running multiple scripts or by an external process, some additional protections are needed. For
+If you want to use SQLite with multiprocessing, some additional protections are needed. For
 these cases, a separate `FileLockSQLiteBucket` class is available. This requires installing the
 [py-filelock](https://py-filelock.readthedocs.io) library.
 ```python

--- a/pyrate_limiter/sqlite_bucket.py
+++ b/pyrate_limiter/sqlite_bucket.py
@@ -23,10 +23,7 @@ class SQLiteBucket(AbstractBucket):
     Notes on concurrency:
 
     * Thread-safe
-    * Safe for use with multiple child processes with a shared initial state and using the same
-      :py:class:`.Limiter` object, e.g. if created with :py:class:`.ProcessPoolExecutor` or
-      :py:class:`multiprocessing.Process`.
-    * For other usage with multiple processes, see :py:class:`.FileLockSQLiteBucket`.
+    * For usage with multiprocessing, see :py:class:`.FileLockSQLiteBucket`.
     * Transactions are locked at the bucket level, but not at the connection or database level.
     * The default isolation level is used (autocommit).
     * Multitple buckets may be used in parallel, but a given bucket will only be used by one


### PR DESCRIPTION
And remove test with `SQLiteBucket` and `ProcessPoolExecutor`.

Fixes #94

Since this only updates docs and a test, it probably doesn't need a patch release. I'll leave that up to you, though.