### PR TITLE
Use poetry-core for build-system instead of full Poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,5 @@ output = 'test-reports/coverage.xml'
 context=7
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
With Poetry 1.1.0, [`poetry-core`](https://pypi.org/project/poetry-core/) was split out so that `pip` and `tox` (with isolated builds) would not have to install Poetry and all of its dependencies.

From a Linux distribution perspective, this also allows a system package to be built where `poetry-core` is available but `poetry` is not, e.g., [EPEL9](https://docs.fedoraproject.org/en-US/epel/).