### PR TITLE
Fix LICENSE file not to be installed into site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 include = [
-    "LICENSE",
+    { path = "LICENSE", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
The `include` directory includes the `LICENSE` files both in sdist and wheel archives by default, effectively causing it to be installed straight into site-packages, i.e.:

    /usr/lib/python3.10/site-packages/LICENSE

Limit it to `sdist` format to prevent that.

Fixes #92