### PR TITLE
Include docs and tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
 ]
 include = [
     { path = "LICENSE", format = "sdist" },
+    { path = "docs", format = "sdist" },
+    { path = "tests", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This will make it possible for packages to use sdist from PyPI to build distribution packages.