### PR TITLE
Make try_acquire awaitable

### DIFF
--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -250,7 +250,7 @@ class Limiter:
 
         return _handle_result(acquire)  # type: ignore
 
-    def try_acquire(self, name: str, weight: int = 1) -> Union[bool, Awaitable[bool]]:
+    async def try_acquire(self, name: str, weight: int = 1) -> Union[bool, Awaitable[bool]]:
         """Try accquiring an item with name & weight
         Return true on success, false on failure
         """


### PR DESCRIPTION
At the moment when I run this:
```
import asyncio

from pyrate_limiter import Duration, Rate, Limiter

rate = Rate(5, Duration.SECOND * 2)
limiter = Limiter(rate)


async def main():
    await limiter.try_acquire('name', 1)


asyncio.run(main())
```

I get this error: 
```
TypeError: object bool can't be used in 'await' expression
```
Not sure if this is all that's needed to fix it, but for me it seems to work.
