### PR TITLE
add reflected ops to Duration

### DIFF
--- a/pyrate_limiter/abstracts/rate.py
+++ b/pyrate_limiter/abstracts/rate.py
@@ -16,8 +16,14 @@ class Duration(Enum):
     def __mul__(self, mutiplier: float) -> int:
         return int(self.value * mutiplier)
 
+    def __rmul__(self, multiplier: float) -> int:
+        return self.__mul__(multiplier)
+
     def __add__(self, another_duration: Union["Duration", int]) -> int:
         return self.value + int(another_duration)
+
+    def __radd__(self, another_duration: Union["Duration", int]) -> int:
+        return self.__add__(another_duration)
 
     def __int__(self) -> int:
         return self.value

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -9,12 +9,12 @@ def test_duration():
     assert int(Duration.SECOND) == 1000
     assert Duration.SECOND.value == 1000
 
-    assert Duration.SECOND * 60 == Duration.MINUTE.value == int(Duration.MINUTE)
-    assert Duration.MINUTE * 60 == Duration.HOUR.value == int(Duration.HOUR)
-    assert Duration.HOUR * 24 == Duration.DAY.value == int(Duration.DAY)
-    assert Duration.DAY * 7 == Duration.WEEK.value == int(Duration.WEEK)
+    assert Duration.SECOND * 60 == 60 * Duration.SECOND == Duration.MINUTE.value == int(Duration.MINUTE)
+    assert Duration.MINUTE * 60 == 60 * Duration.MINUTE == Duration.HOUR.value == int(Duration.HOUR)
+    assert Duration.HOUR * 24 == 24 * Duration.DAY == Duration.DAY.value == int(Duration.DAY)
+    assert Duration.DAY * 7 == 7 * Duration.DAY == Duration.WEEK.value == int(Duration.WEEK)
     assert Duration.DAY + Duration.DAY == Duration.DAY * 2
-    assert Duration.MINUTE + 30000 == 90000
+    assert Duration.MINUTE + 30000 == 30000 + Duration.MINUTE == 90000
 
 
 def test_readable_duration():


### PR DESCRIPTION
Since we already have the comfort of multiplying a `Duration` by an integer, let's go all the way and allow multiplying an integer by a `Duration` for maximum comfort.