### PR TITLE
Fix typing for decorators

### DIFF
--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -6,7 +6,7 @@ from functools import wraps
 from inspect import isawaitable
 from threading import RLock
 from time import sleep
-from typing import Any
+from typing import Any, TypeVar
 from typing import Awaitable
 from typing import Callable
 from typing import List
@@ -27,8 +27,9 @@ from .exceptions import LimiterDelayException
 
 logger = logging.getLogger("pyrate_limiter")
 
+F = TypeVar("F", bound=Callable[..., Any])
 ItemMapping = Callable[[Any], Tuple[str, int]]
-DecoratorWrapper = Callable[[Callable[[Any], Any]], Callable[[Any], Any]]
+DecoratorWrapper = Callable[[F], F]
 
 
 class SingleBucketFactory(BucketFactory):
@@ -303,8 +304,8 @@ class Limiter:
         Use with both sync & async function
         """
 
-        def with_mapping_func(mapping: ItemMapping) -> DecoratorWrapper:
-            def decorator_wrapper(func: Callable[[Any], Any]) -> Callable[[Any], Any]:
+        def with_mapping_func(mapping: ItemMapping):
+            def decorator_wrapper(func: F) -> F:
                 """Actual function warpper"""
 
                 @wraps(func)

--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -6,12 +6,13 @@ from functools import wraps
 from inspect import isawaitable
 from threading import RLock
 from time import sleep
-from typing import Any, TypeVar
+from typing import Any
 from typing import Awaitable
 from typing import Callable
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import TypeVar
 from typing import Union
 
 from .abstracts import AbstractBucket
@@ -305,7 +306,7 @@ class Limiter:
         """
 
         def with_mapping_func(mapping: ItemMapping):
-            def decorator_wrapper(func: F) -> F:
+            def decorator_wrapper(func: F):
                 """Actual function warpper"""
 
                 @wraps(func)


### PR DESCRIPTION
Use generics to pass along the correct typing of the decorated functions.

The original type annotation is actually wrong, because it forces the wrapped function to have only 1 argument, which makes `mypy` complains.

<img width="709" alt="image" src="https://github.com/vutran1710/PyrateLimiter/assets/335541/3872419d-b795-43e8-8a8b-b347666f7793">
