### PR TITLE
Updated LUA script to avoid CROSSSLOT errors when using a Redis cluster

### DIFF
--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -97,9 +97,7 @@ class RedisBucket(AbstractBucket):
         return cls(rates, redis, bucket_key, script_hash)
 
     def _check_and_insert(self, item: RateItem) -> Union[Rate, None, Awaitable[Optional[Rate]]]:
-        keys = [
-            self.bucket_key
-        ]
+        keys = [self.bucket_key]
 
         args = [
             item.timestamp,
@@ -107,7 +105,7 @@ class RedisBucket(AbstractBucket):
             # NOTE: this is to avoid key collision since we are using ZSET
             f"{item.name}:{id_generator()}:",
             len(self.rates),
-            *[value for rate in self.rates for value in (rate.interval, rate.limit)]
+            *[value for rate in self.rates for value in (rate.interval, rate.limit)],
         ]
 
         idx = self.redis.evalsha(self.script_hash, len(keys), *keys, *args)


### PR DESCRIPTION
When using a Redis Cluster, LUA scripts may strictly enforce the meaning of KEYS and ARGS. Specifically, strings in KEYS need to reflect keys in the Redis keyspace, and their hash portion is used to determine the slot where the key resides. The original LUA script conflated KEYS and ARGS. This caused CROSSSLOT errors. This PR separates KEYS and ARGS to avoid these issues.

This fixes issue https://github.com/vutran1710/PyrateLimiter/issues/126.