### PR TITLE
fix: async bucket_factory.get()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyrate-limiter"
-version = "3.6.0"
+version = "3.6.1"
 description = "Python Rate-Limiter using Leaky-Bucket Algorithm"
 authors = ["vutr <me@vutr.io>"]
 license = "MIT"

--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -217,7 +217,7 @@ class BucketFactory(ABC):
         """
 
     @abstractmethod
-    def get(self, item: RateItem) -> AbstractBucket:
+    def get(self, item: RateItem) -> Union[AbstractBucket, Awaitable[AbstractBucket]]:
         """Get the corresponding bucket to this item"""
 
     def create(

--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -252,7 +252,7 @@ class Limiter:
         return _handle_result(acquire)  # type: ignore
 
     def try_acquire(self, name: str, weight: int = 1) -> Union[bool, Awaitable[bool]]:
-        """Try accquiring an item with name & weight
+        """Try acquiring an item with name & weight
         Return true on success, false on failure
         """
         with self.lock:
@@ -260,7 +260,7 @@ class Limiter:
 
             if weight == 0:
                 # NOTE: if item is weightless, just let it go through
-                # NOTE: this might change in the futre
+                # NOTE: this might change in the future
                 return True
 
             item = self.bucket_factory.wrap_item(name, weight)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ from pyrate_limiter import SQLiteQueries as Queries
 from pyrate_limiter import TimeAsyncClock
 from pyrate_limiter import TimeClock
 
-
 # Make log messages visible on test failure (or with pytest -s)
 basicConfig(level="INFO")
 # Uncomment for more verbose output:
@@ -72,7 +71,7 @@ async def create_async_redis_bucket(rates: List[Rate]):
     from redis.asyncio import ConnectionPool as AsyncConnectionPool
     from redis.asyncio import Redis as AsyncRedis
 
-    pool = AsyncConnectionPool.from_url(getenv("REDIS", "redis://localhost:6379"))
+    pool: AsyncConnectionPool = AsyncConnectionPool.from_url(getenv("REDIS", "redis://localhost:6379"))
     redis_db: AsyncRedis = AsyncRedis(connection_pool=pool)
     bucket_key = f"test-bucket/{id_generator()}"
     await redis_db.delete(bucket_key)

--- a/tests/demo_bucket_factory.py
+++ b/tests/demo_bucket_factory.py
@@ -11,6 +11,7 @@ from .helpers import flushing_bucket
 from pyrate_limiter import AbstractBucket
 from pyrate_limiter import AbstractClock
 from pyrate_limiter import BucketFactory
+from pyrate_limiter import id_generator
 from pyrate_limiter import InMemoryBucket
 from pyrate_limiter import RateItem
 from pyrate_limiter import RedisBucket
@@ -65,10 +66,11 @@ class DemoBucketFactory(BucketFactory):
 class DemoAsyncGetBucketFactory(BucketFactory):
     """Async multi-bucket factory used for testing schedule-leaks"""
 
-    def __init__(self, bucket_clock: AbstractClock, **buckets: AbstractBucket):
+    def __init__(self, bucket_clock: AbstractClock, auto_leak=False, **buckets: AbstractBucket):
+        self.auto_leak = auto_leak
         self.clock = bucket_clock
         self.buckets = {}
-        self.thread_pool = None
+        self.leak_interval = 300
 
         for item_name_pattern, bucket in buckets.items():
             assert isinstance(bucket, AbstractBucket)
@@ -96,10 +98,16 @@ class DemoAsyncGetBucketFactory(BucketFactory):
 
         pool: AsyncConnectionPool = AsyncConnectionPool.from_url(getenv("REDIS", "redis://localhost:6379"))
         redis_db: AsyncRedis = AsyncRedis(connection_pool=pool)
-        bucket = await RedisBucket.init(DEFAULT_RATES, redis_db, f"test_bucket:{item.name}")
+        key = f"test-bucket/{id_generator()}"
+        await redis_db.delete(key)
+        bucket = await RedisBucket.init(DEFAULT_RATES, redis_db, key)
         self.schedule_leak(bucket, self.clock)
         self.buckets.update({item.name: bucket})
         return bucket
+
+    def schedule_leak(self, *args):
+        if self.auto_leak:
+            super().schedule_leak(*args)
 
     async def flush(self):
         for bucket in self.buckets.values():

--- a/tests/demo_bucket_factory.py
+++ b/tests/demo_bucket_factory.py
@@ -7,6 +7,7 @@ from redis.asyncio import ConnectionPool as AsyncConnectionPool
 from redis.asyncio import Redis as AsyncRedis
 
 from .conftest import DEFAULT_RATES
+from .helpers import flushing_bucket
 from pyrate_limiter import AbstractBucket
 from pyrate_limiter import AbstractClock
 from pyrate_limiter import BucketFactory
@@ -99,3 +100,7 @@ class DemoAsyncGetBucketFactory(BucketFactory):
         self.schedule_leak(bucket, self.clock)
         self.buckets.update({item.name: bucket})
         return bucket
+
+    async def flush(self):
+        for bucket in self.buckets.values():
+            await flushing_bucket(bucket)

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -171,7 +171,6 @@ async def test_limiter_01(
 @pytest.mark.asyncio
 async def test_limiter_async_factory_get(
     clock,
-    create_bucket,
     limiter_should_raise,
     limiter_delay,
 ):
@@ -182,14 +181,11 @@ async def test_limiter_async_factory_get(
         max_delay=limiter_delay,
     )
     item = "demo"
-    bucket = await factory.get(factory.wrap_item(item, weight=0))
-    bucket = BucketAsyncWrapper(bucket)
 
     logger.info("If weight = 0, it just passes thru")
     acquire_ok, cost = await async_acquire(limiter, item, weight=0)
     assert acquire_ok
     assert cost <= 10
-    assert await bucket.count() == 0
 
     logger.info("Limiter Test #1")
     await prefilling_bucket(limiter, 0.3, item)
@@ -211,7 +207,7 @@ async def test_limiter_async_factory_get(
             assert acquire_ok
 
     # # Flush before testing again
-    await flushing_bucket(bucket)
+    await factory.flush()
     logger.info("Limiter Test #2")
     await prefilling_bucket(limiter, 0, item)
 
@@ -239,7 +235,7 @@ async def test_limiter_async_factory_get(
             assert acquire_ok
 
     # Flush before testing again
-    await flushing_bucket(bucket)
+    await factory.flush()
     logger.info("Limiter Test #3: exceeding weight")
     await prefilling_bucket(limiter, 0, item)
 


### PR DESCRIPTION
Change-Id: Ib471e7661c7d9808ddad3767806b08f1ef1b9967

I have discovered an error that occurs at runtime when I use `aioredis`'s asyncio redis_client to build the `RedisBucket`. The error message is "Invalid bucket: item: {name}".
I have attempted to fix this bug and would appreciate your assistance with the code review, thank you very much!

```python
class ToolRuntimeMultiBucketFactory(BucketFactory):
    def __init__(self, clock: AbstractClock = TimeClock()):
        self.clock = clock
        self.buckets = {}
        self.thread_pool = None

    def wrap_item(self, runtime: ToolRuntimeParams, weight: int = 1) -> RateItem:
        """Time-stamping item, return a RateItem"""
        now = self.clock.now()
        return ToolRuntimeRateItem(runtime, now, weight=weight)

    async def get(self, item: ToolRuntimeRateItem) -> AbstractBucket:
        rates = _build_rates(item.runtime.quota_obj())
        if item.name not in self.buckets:
            # Use `self.create(..)` method to both initialize new bucket and calling `schedule_leak` on that bucket
            # We can create different buckets with different types/classes here as well
            new_bucket = await RedisBucket.init(rates, async_redis_client, f"rl_bucket:{item.name}")
            self.schedule_leak(new_bucket, self.clock)
            self.buckets.update({item.name: new_bucket})

        bucket: AbstractBucket = self.buckets[item.name]
        bucket.rates = rates
        return bucket
```
