### PR TITLE
Stress testing

### DIFF
--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -165,7 +165,7 @@ class SQLiteBucket(AbstractBucket):
         table: str = "rate_bucket",
         db_path: Optional[str] = None,
         create_new_table: bool = True,
-        use_file_lock: bool = False,
+        use_file_lock: bool = False
     ) -> "SQLiteBucket":
         if db_path is None:
             temp_dir = Path(gettempdir())
@@ -185,12 +185,15 @@ class SQLiteBucket(AbstractBucket):
 
             sqlite_connection = sqlite3.connect(
                 db_path,
-                isolation_level="EXCLUSIVE",
+                isolation_level="DEFERRED",
                 check_same_thread=False,
             )
 
-            if use_file_lock:
-                sqlite_connection.execute("PRAGMA journal_mode=WAL;")
+            # https://www.sqlite.org/wal.html
+            sqlite_connection.execute("PRAGMA journal_mode=WAL;")
+
+            # https://www.sqlite.org/pragma.html#pragma_synchronous
+            sqlite_connection.execute("PRAGMA synchronous=NORMAL;")
 
             if create_new_table:
                 sqlite_connection.execute(


### PR DESCRIPTION
After implementing https://github.com/vutran1710/PyrateLimiter/pull/195, decided to take a moment and run some stress tests.

This PR includes the benchmark, and two fixes required for the benchmark to succeed with SQLiteBucket:
- benchmarks/stress_limiters: Runs a stress test up to 7500 requests per second and measures the elapsed time, using the default limiter, SQLiteBucket and SQLiteBucket with File Locking. 
- Modifies the SQLiteClock to be able to share the lock from the bucket: SQLiteClock can be instantiated with the SQLiteBucket: `SQLiteClock(bucket)`. 
- Enables [synchronous=NORMAL](https://www.sqlite.org/pragma.html#pragma_synchronous) and isolation_level=DEFERRED. Without these, the high stress tests appeared to deadlock.          

(there's one more PR which I'm testing now related to handling total delays)