### PR TITLE
Wait for total delay

### DIFF
--- a/benchmarks/stress_limiters.py
+++ b/benchmarks/stress_limiters.py
@@ -1,0 +1,210 @@
+import logging
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import wait
+from dataclasses import dataclass
+from functools import partial
+from time import perf_counter
+from typing import Callable
+from typing import cast
+from typing import Literal
+from typing import Optional
+
+from pyrate_limiter import Duration
+from pyrate_limiter import Limiter
+from pyrate_limiter import Rate
+from pyrate_limiter import SQLiteBucket
+from pyrate_limiter import SQLiteClock
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TestResult:
+    label: str
+    requests_per_second: int
+    test_duration_seconds: int
+    duration: float
+    num_requests: int
+    percent_from_expected_duration: float
+
+
+def create_sqlite_limiter(rate: Rate, use_fileLock: bool, max_delay: int):
+    bucket = SQLiteBucket.init_from_file([rate], use_file_lock=False)
+
+    if use_fileLock:
+        kwargs = dict(clock=SQLiteClock(bucket))
+    else:
+        kwargs = {}
+    return Limiter(bucket, raise_when_fail=False, max_delay=max_delay, **kwargs)
+
+
+def create_rate_limiter_factory(
+    requests_per_second: int,
+    max_delay_seconds: int,
+    backend: Literal["default", "sqlite", "sqlite_filelock"],
+) -> Callable:
+    """Returns a callable, so it can be used with multiprocessing"""
+    max_delay = max_delay_seconds * 1000  # should never wait for more than 60 seconds
+    rate = Rate(requests_per_second, Duration.SECOND)
+
+    if backend == "default":
+        return partial(Limiter, rate, raise_when_fail=False, max_delay=max_delay)
+    elif backend == "sqlite":
+        return partial(
+            create_sqlite_limiter, rate, use_fileLock=False, max_delay=max_delay
+        )
+    elif backend == "sqlite_filelock":
+        return partial(
+            create_sqlite_limiter, rate, use_fileLock=True, max_delay=max_delay
+        )
+    else:
+        raise ValueError(f"Unexpected backend option: {backend}")
+
+
+SHARED_LIMITER = None
+
+
+def task(call_times):
+    try:
+        if SHARED_LIMITER:
+            SHARED_LIMITER.try_acquire("task")
+        call_times.append(perf_counter())
+    except Exception as e:
+        logger.exception(e)
+
+
+def limiter_init(limiter_factory: Callable[[], object]):
+    global SHARED_LIMITER
+    SHARED_LIMITER = limiter_factory()
+
+
+def test_rate_limiter(
+    limiter_factory: Optional[Callable[[], object]],
+    num_requests: int,
+    use_process_pool: bool,
+):
+    call_times: list[float] = []
+
+    start = perf_counter()
+
+    if use_process_pool:
+        logger.info("Using ProcessPoolExecutor")
+        with ProcessPoolExecutor(
+            initializer=partial(limiter_init, limiter_factory) if limiter_factory is not None else None
+        ) as executor:
+            futures = [executor.submit(task, call_times) for _ in range(num_requests)]
+            wait(futures)
+    else:
+        with ThreadPoolExecutor() as executor:
+            limiter = limiter_factory() if limiter_factory is not None else None
+            global SHARED_LIMITER
+            SHARED_LIMITER = limiter
+
+            futures = [executor.submit(task, call_times) for _ in range(num_requests)]
+            wait(futures)
+
+    for f in futures:
+        try:
+            f.result()
+        except Exception as e:
+            print(f"Task raised: {e}")
+
+    end = perf_counter()
+
+    return end - start
+
+
+def run_test_limiter(
+    limiter: Callable | None,
+    label: str,
+    requests_per_second: int,
+    test_duration_seconds: int,
+    use_process_pool: bool = False,
+):
+    num_requests = (
+        test_duration_seconds * requests_per_second
+    )  # should finish in around 20 seconds
+
+    duration = test_rate_limiter(
+        limiter, num_requests=num_requests, use_process_pool=use_process_pool
+    )
+
+    percent_from_expected_duration = (
+        abs(duration) - test_duration_seconds
+    ) / test_duration_seconds
+
+    return TestResult(
+        label=label,
+        requests_per_second=requests_per_second,
+        test_duration_seconds=test_duration_seconds,
+        duration=duration,
+        num_requests=num_requests,
+        percent_from_expected_duration=percent_from_expected_duration,
+    )
+
+
+if __name__ == "__main__":
+    import pandas as pd
+    import plotly.express as px
+
+    requests_per_second_list = [10, 100, 1000, 2500, 5000, 7500]
+    test_duration_seconds = 5
+
+    test_results = []
+
+    logging.basicConfig(
+        format="%(asctime)s %(name)s %(levelname)-8s %(message)s",
+        level=logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    for requests_per_second in requests_per_second_list:
+        logger.info(f"Testing with no rate limiting, {requests_per_second=}")
+        result = run_test_limiter(
+            limiter=None,
+            label="Threads: No Limiter",
+            requests_per_second=requests_per_second,
+            test_duration_seconds=test_duration_seconds,
+        )
+        test_results.append(result)
+
+    for backend in ["default", "sqlite", "sqlite_filelock"]:
+        backend = cast(Literal["default", "sqlite", "sqlite_filelock"], backend)
+        for requests_per_second in requests_per_second_list:
+            logger.info(f"Testing with {backend=}, {requests_per_second=}")
+            limiter = create_rate_limiter_factory(
+                requests_per_second, max_delay_seconds=60, backend=backend
+            )
+            result = run_test_limiter(
+                limiter=limiter,
+                label="Threads: " + backend,
+                requests_per_second=requests_per_second,
+                test_duration_seconds=test_duration_seconds,
+            )
+            test_results.append(result)
+
+    logger.info("Testing Multiprocessing")
+    for requests_per_second in requests_per_second_list:
+        logger.info(f"Testing with {backend=}, {requests_per_second=}")
+
+        limiter_factory = create_rate_limiter_factory(
+            requests_per_second, max_delay_seconds=60, backend="sqlite_filelock"
+        )
+        result = run_test_limiter(
+            limiter=limiter_factory,
+            label="Processes: " + backend,
+            requests_per_second=requests_per_second,
+            test_duration_seconds=test_duration_seconds,
+            use_process_pool=True,
+        )
+        test_results.append(result)
+
+    results_df = pd.DataFrame(test_results).sort_values(by="requests_per_second")
+    results_df["requests_per_second"] = results_df["requests_per_second"].astype(str)
+    fig = px.line(
+        results_df, x="requests_per_second", y="duration", color="label", markers=True
+    )
+    fig.write_html("chart.html")
+
+    logger.info("Output written to chart.html")

--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -165,7 +165,7 @@ class SQLiteBucket(AbstractBucket):
         table: str = "rate_bucket",
         db_path: Optional[str] = None,
         create_new_table: bool = True,
-        use_file_lock: bool = False,
+        use_file_lock: bool = False
     ) -> "SQLiteBucket":
         if db_path is None:
             temp_dir = Path(gettempdir())
@@ -185,12 +185,15 @@ class SQLiteBucket(AbstractBucket):
 
             sqlite_connection = sqlite3.connect(
                 db_path,
-                isolation_level="EXCLUSIVE",
+                isolation_level="DEFERRED",
                 check_same_thread=False,
             )
 
-            if use_file_lock:
-                sqlite_connection.execute("PRAGMA journal_mode=WAL;")
+            # https://www.sqlite.org/wal.html
+            sqlite_connection.execute("PRAGMA journal_mode=WAL;")
+
+            # https://www.sqlite.org/pragma.html#pragma_synchronous
+            sqlite_connection.execute("PRAGMA synchronous=NORMAL;")
 
             if create_new_table:
                 sqlite_connection.execute(

--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -64,6 +64,7 @@ class Limiter:
 
     bucket_factory: BucketFactory
     raise_when_fail: bool
+    retry_until_max_delay: bool
     max_delay: Optional[int] = None
     lock: RLock
 
@@ -73,13 +74,14 @@ class Limiter:
         clock: AbstractClock = TimeClock(),
         raise_when_fail: bool = True,
         max_delay: Optional[Union[int, Duration]] = None,
+        retry_until_max_delay: bool = False
     ):
         """Init Limiter using either a single bucket / multiple-bucket factory
         / single rate / rate list
         """
         self.bucket_factory = self._init_bucket_factory(argument, clock=clock)
         self.raise_when_fail = raise_when_fail
-
+        self.retry_until_max_delay = retry_until_max_delay
         if max_delay is not None:
             if isinstance(max_delay, Duration):
                 max_delay = int(max_delay)
@@ -179,25 +181,39 @@ class Limiter:
                 nonlocal delay
                 delay = await delay
                 assert isinstance(delay, int), "Delay not integer"
-                delay += 50
 
-                if delay > self.max_delay:
-                    logger.error(
-                        "Required delay too large: actual=%s, expected=%s",
-                        delay,
-                        self.max_delay,
-                    )
-                    self._raise_delay_exception_if_necessary(bucket, item, delay)
-                    return False
+                total_delay = 0
 
-                await asyncio.sleep(delay / 1000)
-                item.timestamp += delay
-                re_acquire = bucket.put(item)
+                while True:
+                    delay += 50
+                    total_delay += delay
 
-                if isawaitable(re_acquire):
-                    re_acquire = await re_acquire
+                    if delay > self.max_delay:
+                        logger.error(
+                            "Required delay too large: actual=%s, expected=%s",
+                            delay,
+                            self.max_delay,
+                        )
+                        self._raise_delay_exception_if_necessary(bucket, item, delay)
+                        return False
 
-                return _handle_reacquire(re_acquire)
+                    if total_delay > self.max_delay:
+                        logger.error("Total delay exceeded max_delay: total_delay=%s, max_delay=%s",
+                                     total_delay, self.max_delay)
+                        self._raise_delay_exception_if_necessary(bucket, item, total_delay)
+                        return False
+
+                    await asyncio.sleep(delay / 1000)
+                    item.timestamp += delay
+                    re_acquire = bucket.put(item)
+
+                    if isawaitable(re_acquire):
+                        re_acquire = await re_acquire
+
+                    if not self.retry_until_max_delay:
+                        return _handle_reacquire(re_acquire)
+                    elif re_acquire:
+                        return True
 
             return _handle_async()
 
@@ -213,23 +229,36 @@ class Limiter:
             self._raise_bucket_full_if_necessary(bucket, item)
             return False
 
-        delay += 50
+        total_delay = 0
 
-        if delay > self.max_delay:
-            logger.error(
-                "Required delay too large: actual=%s, expected=%s",
-                delay,
-                self.max_delay,
-            )
-            self._raise_delay_exception_if_necessary(bucket, item, delay)
-            return False
+        while True:
+            logger.info(f"{delay=}, {total_delay=}")
+            delay = bucket.waiting(item)
+            assert isinstance(delay, int)
+            delay += 50
+            total_delay += delay
 
-        sleep(delay / 1000)
-        item.timestamp += delay
-        re_acquire = bucket.put(item)
-        # NOTE: if delay is not Awaitable, then `bucket.put` is not Awaitable
-        assert isinstance(re_acquire, bool)
-        return _handle_reacquire(re_acquire)
+            if total_delay > self.max_delay:
+                logger.error(
+                    "Required delay too large: actual=%s, expected=%s",
+                    delay,
+                    self.max_delay,
+                )
+                self._raise_delay_exception_if_necessary(bucket, item, delay)
+                self._raise_delay_exception_if_necessary(bucket, item, total_delay)
+
+                return False
+
+            sleep(delay / 1000)
+            item.timestamp += delay
+            re_acquire = bucket.put(item)
+            # NOTE: if delay is not Awaitable, then `bucket.put` is not Awaitable
+            assert isinstance(re_acquire, bool)
+
+            if not self.retry_until_max_delay:
+                return _handle_reacquire(re_acquire)
+            elif re_acquire:
+                return True
 
     def handle_bucket_put(
         self,


### PR DESCRIPTION
Fixes: https://github.com/vutran1710/PyrateLimiter/issues/191

Longer explanation: https://github.com/vutran1710/PyrateLimiter/issues/191#issuecomment-3092439001

This PR adds a `retry_until_max_delay` parameter to Limiter, which keeps retrying to acquire up to `max_delay` time. When enabled, `try_acquire` will keep retrying rather than failing if it's not able to acquire after the `delay` expires. This is particularly important in distributed and async cases, where many writers may be concurrently consuming from the rate limiter. In these cases, it's reasonable to expect that multiple delays may be needed. 

This also came up when [stress testing](https://github.com/vutran1710/PyrateLimiter/pull/198) the SQLiteBucket, especially when multiprocessing.

Commentary:
- The change is meant to have no impact by default: `retry_until_max_delay=False`
- I went with the least disruptive approach, but I find the current behavior confusing as mentioned in my comment above. `try_acquire` seems like it should be blocking, yet returns False under a seemingly normal case: where it wasn't able to acquire the lock after a single delay.  

To verify in Redis: 

```
docker run -d --name redis-test -p 6379:6379 redis:7
```
```py
import time
import asyncio
from datetime import datetime
from redis.asyncio import Redis
from pyrate_limiter import Duration, Rate, Limiter, RedisBucket

rate_limits = [Rate(3, Duration.SECOND * 3)]
redis = Redis(host="localhost")
bucket = await RedisBucket.init(rate_limits, redis, "test")

limiter = Limiter(bucket, raise_when_fail=False, max_delay=Duration.DAY, retry_until_max_delay=True)

async def task(name, weight):
    acquired = await limiter.try_acquire(name, weight)
    print(f"{datetime.now()} {name}: {weight}, {acquired=}")

start = time.time()
# Works good
for i in range(10):
    await task(str(i), 1)
print(f'Run 10 calls in {time.time() - start:,.2f} sec')

await asyncio.sleep(3)

# Doen't work
start = time.time()
await asyncio.gather(*[task(str(i), 1) for i in range(10)])
print(f'Run 10 calls in {time.time() - start:,.2f} sec')
```