### PR TITLE
Postgres Performance tuning: Don't use executemany

### DIFF
--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -9,8 +9,6 @@ from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Union
 
-from psycopg2.extras import execute_batch
-
 from ..abstracts import AbstractBucket
 from ..abstracts import Rate
 from ..abstracts import RateItem
@@ -98,13 +96,11 @@ class PostgresBucket(AbstractBucket):
             self.failing_rate = None
 
             query = Queries.PUT.format(table=self._full_tbl)
-            arguments = [(item.name, item.weight, item.timestamp / 1000)] * item.weight
 
             # https://www.psycopg.org/docs/extras.html#fast-exec
-            if item.weight == 1:
-                conn.execute(query, arguments)
-            else:
-                execute_batch(conn, query, [arguments] * item.weight)
+
+            for _ in range(item.weight):
+                conn.execute(query, (item.name, item.weight, item.timestamp / 1000))
 
         return True
 

--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -104,7 +104,7 @@ class PostgresBucket(AbstractBucket):
             if item.weight == 1:
                 conn.execute(query, arguments)
             else:
-                execute_batch(conn, query, arguments)
+                execute_batch(conn, query, [arguments] * item.weight)
 
         return True
 

--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -9,6 +9,8 @@ from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Union
 
+from psycopg2.extras import execute_batch
+
 from ..abstracts import AbstractBucket
 from ..abstracts import Rate
 from ..abstracts import RateItem
@@ -97,7 +99,12 @@ class PostgresBucket(AbstractBucket):
 
             query = Queries.PUT.format(table=self._full_tbl)
             arguments = [(item.name, item.weight, item.timestamp / 1000)] * item.weight
-            conn.executemany(query, tuple(arguments))
+
+            # https://www.psycopg.org/docs/extras.html#fast-exec
+            if item.weight == 1:
+                conn.execute(query, arguments)
+            else:
+                execute_batch(conn, query, arguments)
 
         return True
 


### PR DESCRIPTION
When testing for https://github.com/vutran1710/PyrateLimiter/pull/198, noted that postgres would come to a severe slowdown under high load. The stress test ran for more than 30 minutes (and hung) against postgres without the change, and took about 2 minutes with the change. 

Replacing executemany with execute had a significant performance improvement. 

This follows the advice in https://www.psycopg.org/docs/cursor.html#cursor.executemany, "Warning In its current implementation this method is not faster than executing [execute()](https://www.psycopg.org/docs/cursor.html#cursor.execute) in a loop.". 
