### PR TITLE
Fix cursor leaks in the sqlite3 backend

### DIFF
--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -99,7 +99,9 @@ class SQLiteBucket(AbstractBucket):
     def put(self, item: RateItem) -> bool:
         with self.lock:
             query, parameters = self._build_full_count_query(item.timestamp)
-            rate_limit_counts = self.conn.execute(query, parameters).fetchall()
+            cur = self.conn.execute(query, parameters)
+            rate_limit_counts = cur.fetchall()
+            cur.close()
 
             for idx, result in enumerate(rate_limit_counts):
                 interval, count = result
@@ -115,7 +117,7 @@ class SQLiteBucket(AbstractBucket):
                 [f"('{name}', {item.timestamp})" for name in [item.name] * item.weight]
             )
             query = (Queries.PUT_ITEM.format(table=self.table)) % items
-            self.conn.execute(query)
+            self.conn.execute(query).close()
             self.conn.commit()
             return True
 
@@ -128,28 +130,35 @@ class SQLiteBucket(AbstractBucket):
                 interval=self.rates[-1].interval,
                 current_timestamp=current_timestamp,
             )
-            count = self.conn.execute(query).fetchone()[0]
+            cur = self.conn.execute(query)
+            count = cur.fetchone()[0]
             query = Queries.LEAK.format(table=self.table, count=count)
-            self.conn.execute(query)
+            cur.execute(query)
+            cur.close()
             self.conn.commit()
             return count
 
     def flush(self) -> None:
         with self.lock:
-            self.conn.execute(Queries.FLUSH.format(table=self.table))
+            self.conn.execute(Queries.FLUSH.format(table=self.table)).close()
             self.conn.commit()
             self.failing_rate = None
 
     def count(self) -> int:
         with self.lock:
-            return self.conn.execute(
+            cur = self.conn.execute(
                 Queries.COUNT_ALL.format(table=self.table)
-            ).fetchone()[0]
+            )
+            ret = cur.fetchone()[0]
+            cur.close()
+            return ret
 
     def peek(self, index: int) -> Optional[RateItem]:
         with self.lock:
             query = Queries.PEEK.format(table=self.table, count=index)
-            item = self.conn.execute(query).fetchone()
+            cur = self.conn.execute(query)
+            item = cur.fetchone()
+            cur.close()
 
             if not item:
                 return None
@@ -195,11 +204,12 @@ class SQLiteBucket(AbstractBucket):
                 check_same_thread=False,
             )
 
+            cur = sqlite_connection.cursor()
             if use_file_lock:
-                sqlite_connection.execute("PRAGMA journal_mode=WAL;")
+                cur.execute("PRAGMA journal_mode=WAL;")
 
             if create_new_table:
-                sqlite_connection.execute(
+                cur.execute(
                     Queries.CREATE_BUCKET_TABLE.format(table=table)
                 )
 
@@ -208,7 +218,8 @@ class SQLiteBucket(AbstractBucket):
                 table_name=table,
             )
 
-            sqlite_connection.execute(create_idx_query)
+            cur.execute(create_idx_query)
+            cur.close()
             sqlite_connection.commit()
 
             return cls(rates, sqlite_connection, table=table, lock=file_lock)

--- a/pyrate_limiter/clocks.py
+++ b/pyrate_limiter/clocks.py
@@ -49,7 +49,9 @@ class SQLiteClock(AbstractClock):
         return cls(conn)
 
     def now(self) -> int:
-        now = self.conn.execute(self.time_query).fetchone()[0]
+        cur = self.conn.execute(self.time_query)
+        now = cur.fetchone()[0]
+        cur.close()
         return int(now)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,8 +96,9 @@ async def create_sqlite_bucket(rates: List[Rate], file_lock: bool = False):
     drop_table_query = Queries.DROP_TABLE.format(table=table_name)
     drop_index_query = Queries.DROP_INDEX.format(index=index_name)
 
-    conn.execute(drop_table_query)
-    conn.execute(drop_index_query)
+    cur = conn.execute(drop_table_query)
+    cur.execute(drop_index_query)
+    cur.close()
     conn.commit()
 
     bucket = SQLiteBucket.init_from_file(


### PR DESCRIPTION
Ensure that all `sqlite3.Cursor` objects are closed.  Notably, these objects are created implicitly and returned by
`sqlite3.Connection.execute()` calls, and failing to close them results in resource leaks.  CPython's aggressive GC usually takes care of destroying them, however PyPy's less aggressive GC does not necessarily do that, possibly causing `SQLITE_BUSY` errors in subsequent calls.

Fixes #204