### PR TITLE
Simplify lock interface for SQLite FileLock and MultiprocessBucket

### DIFF
--- a/.github/workflows/poetry-package.yml
+++ b/.github/workflows/poetry-package.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.13"]
+        python-version: ["3.8", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -47,6 +47,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - uses: snok/install-poetry@v1.4.1
       with:
         virtualenvs-in-project: true

--- a/README.md
+++ b/README.md
@@ -293,11 +293,14 @@ heavy_item = "the-sun"
 limiter.try_acquire(heavy_item, weight=10000)
 ```
 
-If your bucket's backend is `async`, well, we got you covered! Passing `await` to the limiter is enought to make it scream!
+### asyncio: If your tasks are async, use an async bucket with limiter.try_acquire_async
+
 
 ```python
-await limiter.try_acquire(item)
+await limiter.try_acquire_async(item)
 ```
+
+Example: [asyncio_ratelimit.py](examples/asyncio_ratelimit.py)
 
 Alternatively, you can use `Limiter.try_acquire` as a function decorator. But you have to provide a `mapping` function that map the wrapped function's arguments to a proper `limiter.try_acquire` argument - which is a tuple of `(str, int)` or just `str`
 
@@ -316,6 +319,9 @@ def request_function(some_number: int):
 async def async_request_function(some_number: int):
     requests.get('https://example.com')
 ```
+
+Example: [asyncio_decorator.py](examples/asyncio_decorator.py)
+
 
 ### Limiter API
 
@@ -491,9 +497,12 @@ for _ in range(4):
 A few different bucket backends are available:
 
 - **InMemoryBucket**: using python built-in list as bucket
+- **MultiprocessBucket**:  uses a multiprocessing lock for distributed concurrency with a ListProxy as the bucket
 - **RedisBucket**, using err... redis, with both async/sync support
 - **PostgresBucket**, using `psycopg2`
 - **SQLiteBucket**, using sqlite3
+- **BucketAsyncWrapper**: wraps an existing bucket with async interfaces, to avoid blocking the event loop
+
 
 #### InMemoryBucket
 
@@ -507,6 +516,17 @@ bucket = InMemoryBucket(rates)
 ```
 
 This bucket only availabe in `sync` mode. The only constructor argument is `List[Rate]`.
+
+#### MultiprocessBucket
+
+MultiprocessBucket uses a ListProxy to store items within a python multiprocessing pool or ProcessPoolExecutor. Concurrency is enforced via a multiprocessing Lock.
+
+The bucket is shared across instances.
+
+An example is provided in [in_memory_multiprocess](examples/in_memory_multiprocess.py)
+
+Whenever multiprocessing, bucket.waiting calculations will be often wrong because of the concurrency involved. Set Limiter.retry_until_max_delay=True so that the
+item keeps retrying rather than returning False when contention causes an extra delay.
 
 #### RedisBucket
 
@@ -552,6 +572,15 @@ rates = [Rate(5, Duration.MINUTE * 2)]
 bucket = SQLiteBucket.init_from_file(rates)
 ```
 
+```py
+from pyrate_limiter import Rate, Limiter, Duration, SQLiteBucket
+
+requests_per_minute = 5
+rate = Rate(requests_per_minute, Duration.MINUTE)
+bucket = SQLiteBucket.init_from_file([rate], use_file_lock=False)  # set use_file_lock to True if using across multiple processes
+limiter = Limiter(bucket, raise_when_fail=False, max_delay=max_delay)
+```
+
 You can also pass custom arguments to the `init_from_file` following its signature:
 
 ```python
@@ -562,12 +591,17 @@ class SQLiteBucket(AbstractBucket):
         rates: List[Rate],
         table: str = "rate_bucket",
         db_path: Optional[str] = None,
-        create_new_table = True
+        create_new_table = True,
+        use_file_lock: bool = False
     ) -> "SQLiteBucket":
         ...
 ```
 
-If the `db_path` is not provided, it will create a temporary database in memory as `tempdir / "pyrate-limiter.sqlite"`
+Options:
+- `db_path`: If not provided, uses `tempdir / "pyrate-limiter.sqlite"`
+- `use_file_lock`: Should be False for single process workloads. For multi process, uses a [filelock](https://pypi.org/project/filelock/) to ensure single access to the SQLite bucket across multiple processes, allowing multi process rate limiting on a single host.
+
+Example: [limiter_factory.py::create_sqlite_limiter()](pyrate_limiter/limiter_factory.py)
 
 #### PostgresBucket
 
@@ -586,14 +620,22 @@ rates = [Rate(3, 1000), Rate(4, 1500)]
 bucket = PostgresBucket(connection_pool, "my-bucket-table", rates)
 ```
 
-### Async or Sync?
+#### BucketAsyncWrapper
+The BucketAsyncWrapper wraps a sync bucket to ensure all its methods return awaitables. This allows the Limiter to detect
+asynchronous behavior and use asyncio.sleep() instead of time.sleep() during delay handling,
+preventing blocking of the asyncio event loop.
 
-The Limiter is basically made of a Clock backend and a Bucket backend. Depends on how each of these component works async-or-sync wise, PyrateLimiter will change its methods' signatures to sync or async accordingly.
+Example: [limiter_factory.py::create_inmemory_limiter()](pyrate_limiter/limiter_factory.py)
 
-Here is a simple rule how to know which mode the Limiter is operating on:
+### Async or Sync or Multiprocessing
 
-> If either of the backends is async-based component, the Limiter will be async.
+The Limiter is basically made of a Clock backend and a Bucket backend. The backends may be async or sync, which determines the Limiters internal behavior, regardless of whether the caller enters via a sync or async function.
 
+try_acquire_async: When calling from an async context, use try_acquire_async. This uses a thread-local asyncio lock to ensure only one asyncio task is acquiring, followed by a global RLock so that only one thread is acquiring.
+
+try_acquire: When called directly, the global RLock enforces only one thread at a time.
+
+Multiprocessing: If using MultiprocessBucket, two locks are used in Limiter: a top level multiprocessing lock, then a thread level RLock
 
 
 ## Advanced Usage

--- a/benchmarks/stress_limiters.py
+++ b/benchmarks/stress_limiters.py
@@ -46,11 +46,9 @@ def create_sqlite_limiter(rate: Rate, use_fileLock: bool, max_delay: int):
 
 
 def create_mp_limiter(max_delay: int, bucket: MultiprocessBucket):
-
     limiter = Limiter(bucket, raise_when_fail=False, clock=MonotonicClock(),
+                      retry_until_max_delay=True,
                       max_delay=max_delay)
-
-    limiter.lock = bucket.get_combined_lock(limiter.lock)  # type: ignore[assignment]
 
     return limiter
 

--- a/examples/in_memory_multiprocess.py
+++ b/examples/in_memory_multiprocess.py
@@ -1,0 +1,82 @@
+"""
+Demonstrates using a MultiprocessBucket using a ProcessPoolExecutor, running a simple task.
+
+A MultiprocessBucket is useful when the rate is to be shared among a multiprocessing pool or ProcessPoolExecutor.
+
+The mp_bucket stores its items in a multiprocessing ListProxy, and a multiprocessing lock is shared
+across Limiter instances.
+
+"""
+import logging
+import os
+import time
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import wait
+from functools import partial
+from multiprocessing import Lock
+
+from pyrate_limiter import Duration
+from pyrate_limiter import Limiter
+from pyrate_limiter import MonotonicClock
+from pyrate_limiter import MultiprocessBucket
+from pyrate_limiter import Rate
+
+LIMITER: Limiter | None = None
+MAX_DELAY = Duration.DAY
+REQUESTS_PER_SECOND = 100
+NUM_REQUESTS = REQUESTS_PER_SECOND * 5  # Run for ~5 seconds
+
+logger = logging.getLogger(__name__)
+
+
+def init_process(bucket: MultiprocessBucket):
+    global LIMITER
+
+    LIMITER = Limiter(bucket, raise_when_fail=False, clock=MonotonicClock(),
+                      max_delay=MAX_DELAY, retry_until_max_delay=True)
+
+
+def my_task():
+    assert LIMITER is not None
+    LIMITER.try_acquire("my_task")
+    result = {"time": time.monotonic(), "pid": os.getpid()}
+    return result
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(asctime)s %(name)s %(levelname)-8s %(message)s",
+        level=logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    rate = Rate(REQUESTS_PER_SECOND, Duration.SECOND)
+
+    bucket = MultiprocessBucket.init([rate])
+    mp_lock = Lock()
+
+    # create a limiter and feed it 100 requests to prime it
+    # Otherwise, the test appears to run too fast
+    init_process(bucket)
+    assert LIMITER is not None
+    [LIMITER.try_acquire("test") for _ in range(REQUESTS_PER_SECOND)]
+
+    start = time.monotonic()
+
+    with ProcessPoolExecutor(
+        initializer=partial(init_process, bucket)
+    ) as executor:
+        futures = [executor.submit(my_task) for _ in range(NUM_REQUESTS)]
+        wait(futures)
+
+    times = []
+    for f in futures:
+        try:
+            t = f.result()
+            times.append(t)
+        except Exception as e:
+            print(f"Task raised: {e}")
+
+    end = time.monotonic()
+
+    print(f"Completed {NUM_REQUESTS=} in {end - start} seconds, at a rate of {REQUESTS_PER_SECOND=}")

--- a/examples/sqlite_filelock_multiprocess.py
+++ b/examples/sqlite_filelock_multiprocess.py
@@ -1,0 +1,74 @@
+"""
+Demonstrates using a SQLite Bucket across multiple processes, using a filelock to enforce synchronization.
+
+This is useful in cases where multiple processes are created, possibly at different times or from different
+applications.
+
+The SQLite Bucket uses a .lock file to ensure that only one process is active at a time.
+
+"""
+import logging
+import os
+import time
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import wait
+from functools import partial
+
+from pyrate_limiter import Duration
+from pyrate_limiter import Limiter
+from pyrate_limiter import limiter_factory
+
+LIMITER: Limiter | None = None
+REQUESTS_PER_SECOND = 10
+NUM_REQUESTS = REQUESTS_PER_SECOND * 5  # Run for ~5 seconds
+
+logger = logging.getLogger(__name__)
+
+
+def init_process():
+    global LIMITER
+
+    LIMITER = limiter_factory.create_sqlite_limiter(rate_per_duration=REQUESTS_PER_SECOND,
+                                                    duration=Duration.SECOND,
+                                                    db_path="pyrate_limiter.sqlite",
+                                                    use_file_lock=True)
+
+
+def my_task():
+    assert LIMITER is not None
+    LIMITER.try_acquire("my_task")
+    result = {"time": time.monotonic(), "pid": os.getpid()}
+    return result
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(asctime)s %(name)s %(levelname)-8s %(message)s",
+        level=logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # prime the rates, to show realistic rates
+    init_process()
+    assert LIMITER is not None
+    [LIMITER.try_acquire("test") for _ in range(REQUESTS_PER_SECOND)]
+
+    start = time.monotonic()
+
+    with ProcessPoolExecutor(
+        initializer=partial(init_process)
+    ) as executor:
+        futures = [executor.submit(my_task) for _ in range(NUM_REQUESTS)]
+        wait(futures)
+
+    times = []
+    for f in futures:
+        try:
+            t = f.result()
+            times.append(t)
+        except Exception as e:
+            print(f"Task raised: {e}")
+
+    end = time.monotonic()
+
+    print(f"Completed {NUM_REQUESTS=} in {end - start} seconds, at a rate of {REQUESTS_PER_SECOND=}")

--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -103,6 +103,12 @@ class AbstractBucket(ABC):
         assert isinstance(bound_item, RateItem)
         return _calc_waiting(bound_item)
 
+    def limiter_lock(self) -> Optional[object]:  # type: ignore
+        """An additional lock to be used by Limiter in-front of the thread lock.
+        Intended for multiprocessing environments where a thread lock is insufficient.
+        """
+        return None
+
 
 class Leaker(Thread):
     """Responsible for scheduling buckets' leaking at the background either

--- a/pyrate_limiter/buckets/mp_bucket.py
+++ b/pyrate_limiter/buckets/mp_bucket.py
@@ -26,6 +26,9 @@ class MultiprocessBucket(InMemoryBucket):
         self.items = items
         self.mp_lock = mp_lock
 
+    def limiter_lock(self):
+        return self.mp_lock
+
     @classmethod
     def init(
         cls,
@@ -39,33 +42,3 @@ class MultiprocessBucket(InMemoryBucket):
         mp_lock: LockType = Lock()
 
         return cls(rates=rates, items=shared_items, mp_lock=mp_lock)
-
-    def get_combined_lock(self, lock):
-        """Provides a new Lock that combines mp_lock with the RLock
-        """
-        class CombinedLock:
-            """
-            A context manager that combines multiple locks into a single lock.
-
-            It is used to wrap/replace the Limiter.lock, and is intended to be used only by Limiter.
-
-            Usage:
-                with CombinedLock(lock1, lock2):
-                    # Critical section
-                    pass
-
-            These locks should only be used once at Limiter try_acquire, and always in the same order, to
-            avoid deadlocks.
-            """
-            def __init__(self, *locks):
-                self.locks = locks
-
-            def __enter__(self):
-                for lock in self.locks:
-                    lock.acquire()
-
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                for lock in reversed(self.locks):
-                    lock.release()
-
-        return CombinedLock(self.mp_lock, lock)

--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -72,6 +72,7 @@ class SQLiteBucket(AbstractBucket):
     table: str
     full_count_query: str
     lock: RLock
+    use_limiter_lock: bool
 
     def __init__(
         self, rates: List[Rate], conn: sqlite3.Connection, table: str, lock=None
@@ -81,9 +82,17 @@ class SQLiteBucket(AbstractBucket):
         self.rates = rates
 
         if not lock:
+            self.use_limiter_lock = False
             self.lock = RLock()
         else:
+            self.use_limiter_lock = True
             self.lock = lock
+
+    def limiter_lock(self):
+        if self.use_limiter_lock:
+            return self.lock
+        else:
+            return None
 
     def _build_full_count_query(self, current_timestamp: int) -> Tuple[str, dict]:
         full_query: List[str] = []

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -29,8 +29,6 @@ def init_process_mp(bucket: MultiprocessBucket):
     LIMITER = Limiter(bucket, raise_when_fail=False, clock=TimeClock(),
                       max_delay=MAX_DELAY, retry_until_max_delay=True)
 
-    LIMITER.lock = bucket.get_combined_lock(LIMITER.lock)  # type: ignore[assignment]
-
 
 def my_task():
     assert LIMITER is not None
@@ -65,7 +63,6 @@ def init_process_sqlite(requests_per_second, db_path):
                       max_delay=MAX_DELAY,
                       retry_until_max_delay=True,
                       clock=SQLiteClock(bucket))
-    LIMITER.lock = bucket.lock
 
 
 def test_mp_bucket():


### PR DESCRIPTION
When using multiprocessing, the Limiter needs a separate lock to ensure ordering of rate acquisition.

In the prior PRs, this was achieved by replacing the Limiter lock after creation. This has two drawbacks: it's easy to forget (user error), and it replaces the thread RLock which can be a problem when multiprocessing & threading are combined. 

This PR is to clean this up by:
- adding "limiter_lock" to AbstractBucket: This indicates that Limiter should use the buckets lock in addition to the threading Rlock.
- Implementing limiter_lock in SQLiteBucket and MultiprocessBucket: no functionality is added, only an accessor to the internal property - if it should be used.
- Moving a combined_lock contextmanager from MultiprocessBucket to Limiter module, so it is reused across both cases (sqlite and multiprocess)