### PR TITLE
Make the 50ms buffer configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,12 +466,14 @@ them. In that case you pass the `max_delay` argument the maximum value of delay 
 limiter = Limiter(factory, max_delay=500) # Allow to delay up to 500ms
 ```
 
+Limiter has a default buffer_ms of 50ms. This means that when waiting, an additional 50ms will be added per step.
+
 As `max_delay` has been passed as a numeric value, when ingesting item, limiter will:
 
 - First, try to ingest such item using the routed bucket
 - If it fails to put item into the bucket, it will call `wait(item)` on the bucket to see how much time remains until the bucket can consume the item again?
 - Comparing the `wait` value to the `max_delay`.
-- if `max_delay` >= `wait`: delay (wait + 50ms as latency-tolerance) using either `asyncio.sleep` or `time.sleep` until the bucket can consume again
+- if `max_delay` >= `wait`: delay (wait + buffer_ms as latency-tolerance) using either `asyncio.sleep` or `time.sleep` until the bucket can consume again
 - if `max_delay` < `wait`: it raises `LimiterDelayException` if Limiter's `raise_when_fail=True`, otherwise silently fail and return False
 
 Example:

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -183,6 +183,7 @@ async def test_limiter_async_factory_get(
         factory,
         raise_when_fail=limiter_should_raise,
         max_delay=limiter_delay,
+        buffer_ms=5
     )
     item = "demo"
 
@@ -207,7 +208,7 @@ async def test_limiter_async_factory_get(
                 acquire_ok, cost = await async_acquire(limiter, item)
         else:
             acquire_ok, cost = await async_acquire(limiter, item)
-            assert cost > 400
+            assert cost > 350
             assert acquire_ok
 
     # # Flush before testing again

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -101,6 +101,7 @@ async def test_limiter_01(
         factory,
         raise_when_fail=limiter_should_raise,
         max_delay=limiter_delay,
+        buffer_ms=1
     )
     bucket = BucketAsyncWrapper(bucket)
     item = "demo"
@@ -127,7 +128,7 @@ async def test_limiter_01(
                 acquire_ok, cost = await async_acquire(limiter, item)
         else:
             acquire_ok, cost = await async_acquire(limiter, item)
-            assert cost > 400
+            assert cost > 350
             assert acquire_ok
 
     # # Flush before testing again


### PR DESCRIPTION
The Limiter delay includes a safety buffer of 50ms. 

This buffer is referenced twice in Limiter:
https://github.com/vutran1710/PyrateLimiter/blob/4bdec466e8f8fe34dca60ad6a2b7be089952dc0b/pyrate_limiter/limiter.py#L224
https://github.com/vutran1710/PyrateLimiter/blob/4bdec466e8f8fe34dca60ad6a2b7be089952dc0b/pyrate_limiter/limiter.py#L278

This PR
- Moves both references to an attribute: Limiter.buffer_ms
- Allows buffer_ms to be changed at init time. 

## Behavior Changes
The default of 50ms isn't changed. No behavior is changed here.

## 50ms vs less?
50ms is a somewhat long delay. It adds up quickly when rates are measured in seconds. Reducing the default to 5ms or 1ms should be considered. 