### PR TITLE
fix: MultiprocessBucket & 3.14

### DIFF
--- a/pyrate_limiter/buckets/in_memory_bucket.py
+++ b/pyrate_limiter/buckets/in_memory_bucket.py
@@ -66,21 +66,21 @@ class InMemoryBucket(AbstractBucket):
 
             if lower_bound > self.items[-1].timestamp:
                 remove_count = len(self.items)
-                self.items = []
+                del self.items[:]
                 return remove_count
 
             if lower_bound < self.items[0].timestamp:
                 return 0
 
             idx = binary_search(self.items, lower_bound)
-            self.items = self.items[idx:]
+            del self.items[:idx]
             return idx
 
         return 0
 
     def flush(self) -> None:
         self.failing_rate = None
-        self.items = []
+        del self.items[:]
 
     def count(self) -> int:
         return len(self.items)

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -233,6 +233,14 @@ async def test_mp_bucket_async():
         ]
         wait(futures)
 
+        time.sleep(2)
+
+        futures = [
+            executor.submit(my_task_async, num_requests // num_workers)
+            for _ in range(num_workers)
+        ]
+        wait(futures)
+
     times = []
     for f in futures:
         try:


### PR DESCRIPTION
Ran across an issue when testing 3.14:

Under certain conditions, InMemoryBucket overwrites the ListProxy such that the rate limiting isn't respected: the buckets diverge. This requires a small change to InMemoryBucket, so it doesn't reassign self.list, and additional locking. 
This seemed to occur reliably in my wsl system when testing 3.14, altho would occur in other systems.

Added a test to exercise this pattern. 