### PR TITLE
Reduce Pytest concurrency

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -4,10 +4,13 @@ from nox_poetry import session
 # Reuse virtualenv created by poetry instead of creating new ones
 nox.options.reuse_existing_virtualenvs = True
 
+# Manually select serial tests. TODO: Add a "serial" marker
 PYTEST_MP_ARGS = ["--verbose", "--cov=pyrate_limiter", "--maxfail=1", "tests/test_multiprocessing.py"]
-PYTEST_MP2_ARGS = ["--verbose", "--cov=pyrate_limiter", "--maxfail=1", "-m", "mpbucket and monotonic",
+PYTEST_MP2_ARGS = ["--verbose", "--cov=pyrate_limiter", "--cov-append", "--maxfail=1", "-m", "mpbucket and monotonic",
                    "--ignore=tests/test_multiprocessing.py"]
-PYTEST_ARGS = ["--verbose", "--maxfail=1", "-m", "not mpbucket", "--numprocesses=auto",
+
+# Reduce # of cores to 3: one less than GHA runner's cores: timing tests are sensitive to high load
+PYTEST_ARGS = ["--verbose", "--maxfail=1", "-m", "not mpbucket", "--numprocesses=3",
                "--ignore=tests/test_multiprocessing.py"]
 COVERAGE_ARGS = ["--cov=pyrate_limiter", "--cov-append", "--cov-report=term", "--cov-report=xml", "--cov-report=html"]
 


### PR DESCRIPTION
The latest master tests failed despite passing previous.

This is due to "-n auto" which selects the number of cores on the GHA runner. The problem is that many of these tests are sensitive to high load. Selecting -n 3 (one fewer than GHA's runner) seems to improve test reliability. 

This could be made dynamic in future by implementing a `pytest_xdist_auto_num_workers` in conftest.