### PR TITLE
Chore: Switch from Bitnami to official Postgres & Redis docker images

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,9 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       pyrate_redis:
-        image: bitnami/redis:latest
-        env:
-          ALLOW_EMPTY_PASSWORD: yes
+        image: redis:7
         ports:
           - 6379:6379
         # Set health checks to wait until redis has started
@@ -29,13 +27,14 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       pyrate_postgres:
-        image: bitnami/postgresql
+        image: postgres:18
         env:
-          ALLOW_EMPTY_PASSWORD: yes
-          POSTGRESQL_PASSWORD: postgres
-          POSTGRESQL_MAX_CONNECTIONS: 1000
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       fail-fast: true
       matrix:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,34 +1,23 @@
 services:
   redis-master:
-    image: bitnami/redis:latest
-    ports:
-      - "6379:6379"
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-      - REDIS_REPLICATION_MODE=master
-      - REDIS_REPLICA_PASSWORD=""
-    networks:
-      - pyrate-bay
+    image: redis:7
+    command: ["redis-server","--appendonly","yes","--requirepass","changeme"]
+    ports: ["6379:6379"]
+    networks: [pyrate-bay]
 
   redis-slave:
-    image: bitnami/redis:latest
-    ports:
-      - "6380:6379"
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-      - REDIS_MASTER_HOST=redis-master
-      - REDIS_REPLICATION_MODE=slave
-      - REDIS_MASTER_PASSWORD=""
-    networks:
-      - pyrate-bay
+    image: redis:7
+    command: ["redis-server","--replicaof","redis-master","6379","--masterauth","changeme","--requirepass","changeme"]
+    ports: ["6380:6379"]
+    networks: [pyrate-bay]
 
   postgres:
-    image: bitnami/postgresql
+    image: postgres:18
     ports:
       - "5432:5432"
     environment:
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_MAX_CONNECTIONS=1000
+      - POSTGRES_PASSWORD=postgres
+    command: ["postgres","-c","max_connections=1000"]
     networks:
       - pyrate-bay
 


### PR DESCRIPTION
The test workflow is failing due to Bitnami's dropping of support for the free Postgres and Redis images: 

https://github.com/bitnami/containers/issues/83267

This PR drops bitnami's images and switches to the official vendor images for [redis](https://hub.docker.com/_/redis) and [postgres](https://hub.docker.com/_/postgres).

