### PR TITLE
Allow any file extension for SQLite db

### DIFF
--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -209,7 +209,6 @@ class SQLiteBucket(AbstractBucket):
 
         with file_lock_ctx:
             assert db_path is not None
-            assert db_path.endswith(".sqlite"), "Please provide a valid sqlite file path"
 
             sqlite_connection = sqlite3.connect(
                 db_path,


### PR DESCRIPTION
I would like to remove the check that enforces a `.sqlite` file extension for the SQLite backend.

SQLite doesn't require any particular file extension, and there are downstream projects that use `.db` (and probably other extensions).