### PR TITLE
Include docs and tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,20 @@ build-backend = "hatchling.build"
 source = "uv-dynamic-versioning"
 
 [tool.hatch.build.targets.sdist]
-include = ["pyrate_limiter"]
+include = [
+    "pyrate_limiter",
+    "docs",
+    "tests",
+    "examples",
+    "benchmarks",
+    "README.md",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "pyproject.toml",
+    "setup.cfg",
+    "noxfile.py",
+]
 
 [tool.hatch.build.targets.wheel]
 include = ["pyrate_limiter"]


### PR DESCRIPTION
### Motivation
- Downstream packagers require complete source distributions that include documentation sources and tests, and the release workflow builds dists via `uv build` which is driven by hatch's `sdist` include list so those files were previously omitted.

### Description
- Expanded the ` [tool.hatch.build.targets.sdist]` `include` list in `pyproject.toml` to add `docs`, `tests`, `examples`, `benchmarks` and repository metadata files (`README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE`, `pyproject.toml`, `setup.cfg`, `noxfile.py`).

### Testing
- No automated tests were run because this is a configuration-only change (validate by producing an sdist with `uv build` to confirm the added files are present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697332cd959483329ec99c3ae5bc1154)