### PR TITLE
Increase tolerances for timing-sensitive tests

### DIFF
--- a/tests/test_blocking_timeouts.py
+++ b/tests/test_blocking_timeouts.py
@@ -25,7 +25,7 @@ def test_sync_decorator_blocks():
     work()                      # consumes the only slot
     t1 = work()                 # must block ~200ms waiting for leak
     elapsed = t1 - t0
-    assert elapsed >= 0.18
+    assert elapsed >= 0.15
 
 # --- async decorator blocks ---
 @pytest.mark.asyncio
@@ -40,7 +40,7 @@ async def test_async_decorator_blocks():
     await work()               # consumes the only slot
     t1 = await work()          # must block ~200ms
     elapsed = t1 - t0
-    assert elapsed >= 0.18
+    assert elapsed >= 0.15
 
 # --- try_acquire: non-blocking fails on contention ---
 def test_try_acquire_nonblocking_false():
@@ -72,7 +72,7 @@ async def test_try_acquire_async_timeout():
     t1 = time.perf_counter()
 
     assert ok is False                       # timed out
-    assert 0.09 <= (t1 - t0) <= 0.25         # waited ~timeout, not full 200ms
+    assert 0.08 <= (t1 - t0) <= 0.35         # waited ~timeout, not full 200ms
 
 # --- sync timeout enforces max wait ---
 def test_try_acquire_sync_timeout():
@@ -84,7 +84,7 @@ def test_try_acquire_sync_timeout():
     t1 = time.perf_counter()
 
     assert ok is False                        # timed out
-    assert 0.09 <= (t1 - t0) <= 0.25         # waited ~timeout, not full 200ms
+    assert 0.08 <= (t1 - t0) <= 0.35         # waited ~timeout, not full 200ms
 
 
 def test_try_acquire_sync_nonblocking_rejects_timeout():
@@ -132,7 +132,7 @@ async def test_try_acquire_timeout_with_awaitable_wrap_item():
     t1 = time.perf_counter()
 
     assert ok is False
-    assert 0.09 <= (t1 - t0) <= 0.25
+    assert 0.08 <= (t1 - t0) <= 0.35
 
 
 @pytest.mark.asyncio
@@ -179,4 +179,4 @@ async def test_try_acquire_timeout_with_awaitable_get_bucket():
     t1 = time.perf_counter()
 
     assert ok is False
-    assert 0.09 <= (t1 - t0) <= 0.25
+    assert 0.08 <= (t1 - t0) <= 0.35

--- a/tests/test_bucket_all.py
+++ b/tests/test_bucket_all.py
@@ -167,9 +167,9 @@ async def test_bucket_waiting(create_bucket):
     assert isinstance(availability, int)
     logger.info("1 space available in: %s", availability)
 
-    await asyncio.sleep(availability / 1000 - 0.03)
+    await asyncio.sleep(availability / 1000 - 0.02)
     assert await bucket.put(await create_item()) is False
-    await asyncio.sleep(0.04)
+    await asyncio.sleep(0.06)
     assert await bucket.put(await create_item()) is True
 
     assert await bucket.put(await create_item(2)) is False
@@ -177,9 +177,9 @@ async def test_bucket_waiting(create_bucket):
     assert isinstance(availability, int)
     logger.info("2 space available in: %s", availability)
 
-    await asyncio.sleep(availability / 1000 - 0.03)
+    await asyncio.sleep(availability / 1000 - 0.02)
     assert await bucket.put(await create_item(2)) is False
-    await asyncio.sleep(0.04)
+    await asyncio.sleep(0.06)
     assert await bucket.put(await create_item(2)) is True
 
     assert await bucket.put(await create_item(3)) is False
@@ -187,9 +187,9 @@ async def test_bucket_waiting(create_bucket):
     assert isinstance(availability, int)
     logger.info("3 space available in: %s", availability)
 
-    await asyncio.sleep(availability / 1000 - 0.03)
+    await asyncio.sleep(availability / 1000 - 0.02)
     assert await bucket.put(await create_item(3)) is False
-    await asyncio.sleep(0.04)
+    await asyncio.sleep(0.06)
     assert await bucket.put(await create_item(3)) is True
 
 

--- a/tests/test_combinedlock.py
+++ b/tests/test_combinedlock.py
@@ -43,7 +43,7 @@ def test_combined_lock_timeout_when_mp_locked():
     m.acquire()
     try:
         with pytest.raises(TimeoutError):
-            with combined_lock([m, r], blocking=True, timeout=0.05): 
+            with combined_lock([m, r], blocking=True, timeout=0.1):
                 pass
     finally:
         m.release()
@@ -89,7 +89,7 @@ def test_float_timeout():
     m.acquire()
     try:
         with pytest.raises(TimeoutError):
-            with combined_lock([m, r], True, timeout=0.05): pass
+            with combined_lock([m, r], True, timeout=0.1): pass
     finally:
         m.release()
 
@@ -103,7 +103,7 @@ def test_order_doesnt_deadlock_when_second_is_locked():
     m2.acquire()
     try:
         with pytest.raises(TimeoutError):
-            with combined_lock([m1, m2], True, timeout=0.01): pass
+            with combined_lock([m1, m2], True, timeout=0.05): pass
     finally:
         m2.release()
 
@@ -114,7 +114,7 @@ def test_timeout_is_global_budget_across_locks():
     m2.acquire()
 
     def release_first_lock_later():
-        sleep(0.03)
+        sleep(0.1)
         m1.release()
 
     releaser = Thread(target=release_first_lock_later)
@@ -123,11 +123,11 @@ def test_timeout_is_global_budget_across_locks():
 
     try:
         with pytest.raises(TimeoutError):
-            with combined_lock([m1, m2], True, timeout=0.05):
+            with combined_lock([m1, m2], True, timeout=0.2):
                 pass
     finally:
         releaser.join()
         m2.release()
 
     elapsed = monotonic() - started
-    assert elapsed < 0.08
+    assert elapsed < 0.3

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -400,7 +400,7 @@ async def test_wait_too_long():
     # raise_when_fail = True
     limiter = Limiter(bucket)
 
-    tasks = [limiter.try_acquire_async("mytest", 1, timeout=0.0001) for i in range(500)]
+    tasks = [limiter.try_acquire_async("mytest", 1, timeout=0.01) for i in range(500)]
     r = await asyncio.gather(*tasks)
 
     # Not all requests could be satisfied within the timeout

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -50,7 +50,7 @@ def analyze_times(start: float, requests_per_second: int, times: List[float]):
         ops_last_sec.append(len(w))
     print(f"{max(ops_last_sec)=},  {requests_per_second=}")
     assert (
-        max(ops_last_sec) <= requests_per_second * 1.05
+        max(ops_last_sec) <= requests_per_second * 1.1
     )  # a small amount of error is observed when multiprocessing
 
 


### PR DESCRIPTION
Follow-up from #272.

The timing-sensitive tests can be flaky, especially on the CI runner which has a fairly small vCPU. I bumped up the timing checks by 0.02 to 0.1 seconds to account for lock overhead, event loop overhead, etc.
