### PR TITLE
fix(docs): align docstrings and fix: db_path=None temporary DB behavior

### DIFF
--- a/pyrate_limiter/limiter_factory.py
+++ b/pyrate_limiter/limiter_factory.py
@@ -72,7 +72,7 @@ def create_sqlite_limiter(
 
     bucket: AbstractBucket = SQLiteBucket.init_from_file(
         rate_limits,
-        db_path=str(db_path),
+        db_path=db_path,
         table=table_name,
         create_new_table=True,
         use_file_lock=use_file_lock,

--- a/pyrate_limiter/limiter_factory.py
+++ b/pyrate_limiter/limiter_factory.py
@@ -26,7 +26,7 @@ def create_sqlite_bucket(
 
     Args:
         rates: List of rate limit configurations.
-        db_path: Path to the SQLite database file (or in-memory if None).
+        db_path: Path to the SQLite database file. If None, a temporary on-disk SQLite database is created.
         table_name: Name of the table to store rate bucket data.
         use_file_lock: Enable file locking for multi-process synchronization.
 
@@ -59,7 +59,7 @@ def create_sqlite_limiter(
     Args:
         rate_per_duration: Number of allowed requests per duration.
         duration: Time window for the rate limit.
-        db_path: Path to the SQLite database file (or in-memory if None).
+        db_path: Path to the SQLite database file. If None, a temporary on-disk SQLite database is created.
         table_name: Name of the table used for rate buckets.
         buffer_ms: Extra wait time in milliseconds to account for clock drift.
         use_file_lock: Enable file locking for multi-process synchronization.

--- a/pyrate_limiter/limiter_factory.py
+++ b/pyrate_limiter/limiter_factory.py
@@ -20,7 +20,7 @@ def create_sqlite_bucket(
     db_path: Optional[str],
     table_name: str = "pyrate_limiter",
     use_file_lock: bool = False,
-):
+) -> SQLiteBucket:
     """
     Create and initialize a SQLite bucket for rate limiting.
 
@@ -115,7 +115,7 @@ def create_inmemory_limiter(
 def init_global_limiter(
     bucket: AbstractBucket,
     buffer_ms: int = 50,
-):
+) -> None:
     """
     Initialize a global Limiter instance using the provided bucket.
 

--- a/pyrate_limiter/limiter_factory.py
+++ b/pyrate_limiter/limiter_factory.py
@@ -36,7 +36,7 @@ def create_sqlite_bucket(
     logger.info("Table name is %s", table_name)
     bucket = SQLiteBucket.init_from_file(
         rates,
-        db_path=str(db_path),
+        db_path=db_path,
         table=table_name,
         create_new_table=True,
         use_file_lock=use_file_lock,

--- a/pyrate_limiter/limiter_factory.py
+++ b/pyrate_limiter/limiter_factory.py
@@ -54,17 +54,15 @@ def create_sqlite_limiter(
     use_file_lock: bool = False,
 ) -> Limiter:
     """
-    Create a SQLite-backed rate limiter with configurable rate, persistence, and optional async support.
+    Create a SQLite-backed rate limiter with configurable rate, persistence, and file locking.
 
     Args:
         rate_per_duration: Number of allowed requests per duration.
         duration: Time window for the rate limit.
         db_path: Path to the SQLite database file (or in-memory if None).
         table_name: Name of the table used for rate buckets.
-        max_delay: Maximum delay before failing requests.
         buffer_ms: Extra wait time in milliseconds to account for clock drift.
         use_file_lock: Enable file locking for multi-process synchronization.
-        async_wrapper: Whether to wrap the bucket for async usage.
 
     Returns:
         Limiter: Configured SQLite-backed limiter instance.
@@ -91,14 +89,12 @@ def create_inmemory_limiter(
     buffer_ms: int = 50,
 ) -> Limiter:
     """
-    Create an in-memory rate limiter with configurable rate, duration, delay, and optional async support.
+    Create an in-memory rate limiter with configurable rate and clock-drift buffer.
 
     Args:
         rate_per_duration: Number of allowed requests per duration.
         duration: Time window for the rate limit.
-        max_delay: Maximum delay before failing requests.
         buffer_ms: Extra wait time in milliseconds to account for clock drift.
-        async_wrapper: Whether to wrap the bucket for async usage.
 
     Returns:
         Limiter: Configured in-memory limiter instance.
@@ -123,9 +119,6 @@ def init_global_limiter(
 
     Args:
         bucket: The rate-limiting bucket to be used.
-        max_delay: Maximum delay before failing requests.
-        raise_when_fail: Whether to raise an exception when a request fails.
-        retry_until_max_delay: Retry until the maximum delay is reached.
         buffer_ms: Additional buffer time in milliseconds for retries.
     """
 


### PR DESCRIPTION
## Summary

This PR updates documentation and type annotations to match the actual implementation of helper functions in the library. It improves consistency between function signatures, return types, and docstrings.

It also includes a small behavioral fix in the db_path=None case: SQLiteBucket.init_from_file() now passes db_path through unchanged, which allows SQLiteBucket to create a temporary database instead of trying to open a file literally named None.

## Changes
### Added missing return type hints:
- create_sqlite_bucket
- init_global_limiter
### Refactored docstrings for consistency:
- create_sqlite_limiter
- create_inmemory_limiter
- Removed or corrected outdated/incorrect parameter references in docstrings to reflect actual function signatures.

### Fixed
- `SQLiteBucket.init_from_file()` behavior for `db_path=None` so it uses a temporary database instead of a file named `None`.