### PR TITLE
fix: add close() method to avoid ResourceWarning about unclosed transports

### DIFF
--- a/pyrate_limiter/extras/aiohttp_limiter.py
+++ b/pyrate_limiter/extras/aiohttp_limiter.py
@@ -89,3 +89,14 @@ class RateLimitedSession:
             Exception information, if any, from the context block.
         """
         await self._session.close()
+
+    async def close(self) -> None:
+        """
+        Close the underlying aiohttp.ClientSession.
+
+        This method ensures that the internal session is properly closed,
+        avoiding ResourceWarning about unclosed transports. It is safe to
+        call even if the session was already closed or if you did not use
+        the context manager.
+        """
+        await self._session.close()

--- a/tests/test_aiohttp_limiter.py
+++ b/tests/test_aiohttp_limiter.py
@@ -1,0 +1,44 @@
+"""Tests for aiohttp_limiter close() method"""
+import pytest
+from pyrate_limiter import Limiter, Rate
+from pyrate_limiter.extras.aiohttp_limiter import RateLimitedSession
+from .conftest import DEFAULT_RATES
+
+
+@pytest.mark.asyncio
+async def test_close_method_closes_session():
+    """Test that the close() method properly closes the aiohttp session."""
+    limiter = Limiter(DEFAULT_RATES)
+    session = RateLimitedSession(limiter)
+    
+    # Verify session is open
+    assert not session._session.closed
+    
+    # Call close
+    await session.close()
+    
+    # Verify session is closed
+    assert session._session.closed
+
+
+@pytest.mark.asyncio
+async def test_close_idempotent():
+    """Test that close() can be called multiple times without error."""
+    limiter = Limiter(DEFAULT_RATES)
+    session = RateLimitedSession(limiter)
+    
+    # Call close twice
+    await session.close()
+    await session.close()  # Should not raise
+
+
+@pytest.mark.asyncio
+async def test_close_after_context_manager():
+    """Test that close() works after using the context manager."""
+    limiter = Limiter(DEFAULT_RATES)
+    
+    async with RateLimitedSession(limiter) as session:
+        assert not session._session.closed
+    
+    # Context manager already closed, close() should handle this gracefully
+    assert session._session.closed


### PR DESCRIPTION
Fixed the bug described in issue #276.

## Problem
The RateLimitedSession class was missing a public close() method. Users who create a session without using the context manager pattern have no clean way to close it, resulting in ResourceWarning: unclosed transport.

## Solution
Added a public async close() method to RateLimitedSession that properly closes the underlying aiohttp.ClientSession. The method safely calls self._session.close() which is idempotent.

## Testing
- Syntax check passed
- Import test passed
- Follows existing code patterns

Closes #276