### PR TITLE
Typo fix for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/vutran1710/PyrateLimiter"
 Repository = "https://github.com/vutran1710/PyrateLimiter"
-Documentation = "https://pyrate-limiter.readthedocs.io"
+Documentation = "https://pyratelimiter.readthedocs.io"
 
 [dependency-groups]
 all = [


### PR DESCRIPTION
removed an extra dash from `pyproject.toml` pointing to the docs. the current url throws a 404, but the project description and readme had the right url
[issue](https://github.com/vutran1710/PyrateLimiter/issues/281)