### PR TITLE
Batch weighted RedisBucket inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ redis_db = AsyncRedis(connection_pool=AsyncPool.from_url("redis://localhost:6379
 bucket = await RedisBucket.init(rates, redis_db, "bucket-key")
 ```
 
+RedisBucket stores one sorted-set member per consumed unit for exact sliding-window checks. For high-volume, long-window limits such as daily or monthly quotas, the retained sorted set can grow large; use shorter windows or a coarser counter-based backend if predictable memory and latency are more important than exact per-item history.
+
 ### SQLiteBucket
 
 Persists state to SQLite (sync only):

--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -36,23 +36,20 @@ class LuaScript:
     end
 
     local batch = {}
-    local batch_count = 0
     -- Each member adds two unpacked arguments; 1000 stays below Lua 5.1 limits.
     local batch_size = 1000
 
     for i=1,space_required do
-        batch_count = batch_count + 1
-        batch[(batch_count * 2) - 1] = now
-        batch[batch_count * 2] = item_name..i
+        batch[#batch + 1] = now
+        batch[#batch + 1] = item_name..i
 
-        if batch_count == batch_size then
+        if #batch == batch_size * 2 then
             redis.call('ZADD', bucket, unpack(batch))
             batch = {}
-            batch_count = 0
         end
     end
 
-    if batch_count > 0 then
+    if #batch > 0 then
         redis.call('ZADD', bucket, unpack(batch))
     end
 

--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -35,9 +35,27 @@ class LuaScript:
         end
     end
 
+    local batch = {}
+    local batch_count = 0
+    -- Each member adds two unpacked arguments; 1000 stays below Lua 5.1 limits.
+    local batch_size = 1000
+
     for i=1,space_required do
-        redis.call('ZADD', bucket, now, item_name..i)
+        batch_count = batch_count + 1
+        batch[(batch_count * 2) - 1] = now
+        batch[batch_count * 2] = item_name..i
+
+        if batch_count == batch_size then
+            redis.call('ZADD', bucket, unpack(batch))
+            batch = {}
+            batch_count = 0
+        end
     end
+
+    if batch_count > 0 then
+        redis.call('ZADD', bucket, unpack(batch))
+    end
+
     return -1
     """
 

--- a/tests/test_redis_bucket.py
+++ b/tests/test_redis_bucket.py
@@ -1,0 +1,33 @@
+import pytest
+
+from pyrate_limiter import Rate
+from pyrate_limiter import RateItem
+
+from .conftest import create_async_redis_bucket
+from .conftest import create_redis_bucket
+
+pytest.importorskip("redis")
+
+
+@pytest.mark.redis
+@pytest.mark.asyncio
+async def test_redis_bucket_batches_large_weight():
+    bucket = await create_redis_bucket([Rate(1001, 1000)])
+
+    try:
+        assert bucket.put(RateItem("item", bucket.now(), weight=1001)) is True
+        assert bucket.count() == 1001
+    finally:
+        bucket.flush()
+
+
+@pytest.mark.asyncredis
+@pytest.mark.asyncio
+async def test_async_redis_bucket_batches_large_weight():
+    bucket = await create_async_redis_bucket([Rate(1001, 1000)])
+
+    try:
+        assert await bucket.put(RateItem("item", bucket.now(), weight=1001)) is True
+        assert await bucket.count() == 1001
+    finally:
+        await bucket.flush()


### PR DESCRIPTION
## Summary
- batch weighted Redis `ZADD` operations in bounded 1000-member chunks inside the existing atomic Lua script
- document that exact long-window Redis buckets retain one sorted-set member per consumed unit
- cover weighted batches across the boundary for both sync and async Redis clients

## Review changes
- removed the earlier put-time pruning and key TTL changes because they changed `RedisBucket` leak/peek semantics and caused the async concurrency regression
- reused the existing sync and async Redis test helpers
- asserted through the bucket API and cleaned up keys with `flush()`
- documented why the batch size remains below Lua 5.1 `unpack` limits

## Testing
- `env REDIS=redis://localhost:6380 uv run --group all --group dev pytest -q tests/test_redis_bucket.py tests/test_limiter.py::test_limiter_concurrency -m "redis or asyncredis"` (4 passed)
- `env REDIS=redis://localhost:6380 uv run --group all --group dev pytest -q -m "redis or asyncredis" tests` (36 passed)
- `uv run --group dev nox -e lint` (passed: YAML, Ruff check/format, mypy)

## CI note
The Read the Docs failure is inherited from current `master` commit `7d76a13`: its new Mermaid README fence is not configured in Sphinx and the same `latest` build fails with the same warning. PR #295 contains the upstream Mermaid configuration fix and has a green Read the Docs build. This Redis PR intentionally does not duplicate that unrelated docs fix.

## Notes
This improves weighted-put command overhead but does not make exact long-window cardinality constant. High-volume daily/monthly quotas need a separate counter/GCRA-style backend if bounded memory and latency are required.