### PR TITLE
fix: enforce + auto-sort rate lists at the abstract bucket level (#239)

### DIFF
--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -11,6 +11,7 @@ from threading import Event, Thread
 from typing import Any, Awaitable, Dict, List, Optional, Type, Union
 
 from ..clocks import AbstractClock, MonotonicClock
+from ..utils import enforce_rate_list
 from .rate import Rate, RateItem
 
 logger = logging.getLogger("pyrate_limiter")
@@ -22,9 +23,31 @@ class AbstractBucket(ABC):
     TODO: allow empty rates
     """
 
-    rates: List[Rate]
+    _rates: List[Rate]
     failing_rate: Optional[Rate] = None
     _clock: AbstractClock = MonotonicClock()
+
+    @property
+    def rates(self) -> List[Rate]:
+        return self._rates
+
+    @rates.setter
+    def rates(self, value: List[Rate]) -> None:
+        """Sort, validate, and store the rate list.
+
+        Both sorting and validation are enforced here, at the abstract level,
+        so every bucket (built-in or custom) shares the same contract:
+
+        - Rates are sorted by ascending interval. Several backends assume
+          ``rates[-1]`` is the largest interval when leaking (e.g. Redis,
+          SQLite, Postgres), but historically only some buckets sorted -
+          centralizing it fixes that latent leak bug.
+        - The sorted list is then validated, rejecting ill-formed rate lists
+          at construction instead of silently misbehaving (issue #239).
+        """
+        ordered = sorted(value, key=lambda r: r.interval)
+        enforce_rate_list(ordered)
+        self._rates = ordered
 
     def now(self):
         """Retrieve current timestamp from the clock backend."""

--- a/pyrate_limiter/abstracts/wrappers.py
+++ b/pyrate_limiter/abstracts/wrappers.py
@@ -78,3 +78,8 @@ class BucketAsyncWrapper(AbstractBucket):
     @property
     def rates(self):
         return self.bucket.rates
+
+    @rates.setter
+    def rates(self, value):
+        # Delegate to the wrapped bucket, which sorts + validates.
+        self.bucket.rates = value

--- a/pyrate_limiter/buckets/in_memory_bucket.py
+++ b/pyrate_limiter/buckets/in_memory_bucket.py
@@ -22,7 +22,7 @@ class InMemoryBucket(AbstractBucket):
     def __init__(self, rates: List[Rate]):
         super().__init__()
 
-        self.rates = sorted(rates, key=lambda r: r.interval)
+        self.rates = rates  # AbstractBucket.rates setter sorts + validates
         self.items = []
 
     def put(self, item: RateItem) -> bool:

--- a/pyrate_limiter/buckets/mp_bucket.py
+++ b/pyrate_limiter/buckets/mp_bucket.py
@@ -22,7 +22,7 @@ class MultiprocessBucket(InMemoryBucket):
 
         self._clock = MonotonicClock()
 
-        self.rates = sorted(rates, key=lambda r: r.interval)
+        self.rates = rates  # AbstractBucket.rates setter sorts + validates
         self.items = items
         self.mp_lock = mp_lock
 

--- a/pyrate_limiter/utils.py
+++ b/pyrate_limiter/utils.py
@@ -62,6 +62,22 @@ def validate_rate_list(rates: List[Rate]) -> bool:
     return True
 
 
+def enforce_rate_list(rates: List[Rate]) -> None:
+    """Raise ValueError if rates are not a well-formed, ordered rate list.
+
+    A valid list is ordered by strictly increasing interval, with strictly
+    increasing limits and non-increasing density (limit/interval) - i.e. the
+    "generous-before-tight" contract. Pass rates already in the order the
+    bucket will use them (sort first if the bucket sorts).
+    """
+    if not validate_rate_list(rates):
+        raise ValueError(
+            "Invalid rate list: rates must be non-empty and ordered by strictly "
+            "increasing interval, with strictly increasing limits and non-increasing "
+            f"density (limit/interval). Got: {rates}"
+        )
+
+
 def id_generator(
     size=10,
 ) -> str:

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -124,6 +124,26 @@ def test_rate_validator():
     assert validate_rate_list(rates) is True
 
 
+def test_inmemory_bucket_rejects_illformed_rates():
+    """Ill-formed rate lists must raise at construction instead of silently
+    misbehaving (issue #239). InMemoryBucket sorts by interval, so the rates
+    are validated in interval-ascending order."""
+    from pyrate_limiter import InMemoryBucket
+
+    # 3/min AND 1/day: the longer interval has a *smaller* limit -> ill-formed
+    bad_rates = [Rate(3, Duration.MINUTE), Rate(1, Duration.DAY)]
+    assert validate_rate_list(sorted(bad_rates, key=lambda r: r.interval)) is False
+
+    with pytest.raises(ValueError):
+        InMemoryBucket(bad_rates)
+
+    # Well-formed config (generous-before-tight) must still be accepted, and
+    # unordered-but-well-formed input is accepted because the bucket sorts it.
+    InMemoryBucket([Rate(100, Duration.SECOND), Rate(200, Duration.MINUTE)])
+    InMemoryBucket([Rate(200, Duration.MINUTE), Rate(100, Duration.SECOND)])
+    InMemoryBucket([Rate(10, Duration.SECOND)])
+
+
 @pytest.mark.asyncio
 async def test_clock(clock: AbstractClock | None = None):
     """Testing clock backends


### PR DESCRIPTION
## Summary

Closes #239.

Ill-formed rate lists were silently under-enforced. The reporter's example `[Rate(3, MINUTE), Rate(1, DAY)]` — a longer interval with a *smaller* limit — let requests through that the day-limit should have blocked, because the bucket algorithms (InMemoryBucket's `if after_length < rate.limit: break`, and the count-based checks in the SQL/Redis backends) assume a **"generous-before-tight"** contract: strictly increasing interval + limit, non-increasing density. `validate_rate_list()` already encoded this contract but was never called by any bucket.

While investigating, I found a **second, latent bug**: only `InMemoryBucket` and `MultiprocessBucket` sorted their rates, yet *every* backend's `leak()` assumes `rates[-1]` is the largest interval (`postgres.py:138`, `redis_bucket.py:144`, `sqlite_bucket.py:137`). Passing unsorted rates to Redis/SQLite/Postgres silently leaked the wrong window.

## Fix

Both concerns are fixed in one place — a validating `AbstractBucket.rates` property setter that **sorts then validates**:

1. **Sort** by ascending interval → fixes the latent `leak()` bug across all backends, and lets every bucket accept unordered (but well-formed) input.
2. **Validate** the sorted list → raises `ValueError` on ill-formed configs at construction instead of silently misbehaving.

Sorting alone is *not* sufficient — a sorted-but-ill-formed list still defeats the `break` optimization (verified empirically), so validation stays load-bearing. Centralizing at the abstract level means custom buckets get the contract for free.

Also removes the now-redundant per-bucket `sorted()` calls and adds a delegating setter to `BucketAsyncWrapper`.

## Behavior change ⚠️

Constructing a bucket / `Limiter` with an ill-formed rate list now raises `ValueError` instead of silently mis-limiting. Well-formed configs (the documented usage, and all existing tests) are unaffected. Worth a minor-version bump + changelog note.

## Testing

- New unit test `test_inmemory_bucket_rejects_illformed_rates`.
- Full non-service suite: **120 passed, 1 skipped** (the 1 warning is the pre-existing `test_sqlite_filelock_bucket` teardown race, #244 — unrelated).
- `nox -e lint` (ruff + mypy) passes.
- Verified bucket/Limiter pickling still round-trips with `rates` now a property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)