### PR TITLE
fix: compose Postgres SQL with psycopg.sql instead of f-strings (#233)

### DIFF
--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -16,6 +16,13 @@ if TYPE_CHECKING:
 
 
 class Queries:
+    """SQL templates composed via ``psycopg.sql``.
+
+    ``{table}`` / ``{index}`` are quoted identifiers filled with
+    ``sql.SQL(...).format(...)``; ``%s`` are bound query parameters supplied at
+    execution time. Neither uses raw string interpolation (issue #233).
+    """
+
     CREATE_BUCKET_TABLE = """
     CREATE TABLE IF NOT EXISTS {table} (
         name VARCHAR,
@@ -32,6 +39,10 @@ class Queries:
     COUNT = """
     SELECT COUNT(*) FROM {table}
     """
+    COUNT_WINDOW = """
+    SELECT COUNT(*) FROM {table}
+    WHERE item_timestamp >= TO_TIMESTAMP(%s) - (%s * INTERVAL '1 milliseconds')
+    """
     PUT = """
     INSERT INTO {table} (name, weight, item_timestamp) VALUES (%s, %s, TO_TIMESTAMP(%s))
     """
@@ -43,13 +54,13 @@ class Queries:
     FROM {table}
     ORDER BY item_timestamp DESC
     LIMIT 1
-    OFFSET {offset}
+    OFFSET %s
     """
     LEAK = """
-    DELETE FROM {table} WHERE item_timestamp < TO_TIMESTAMP({timestamp})
+    DELETE FROM {table} WHERE item_timestamp < TO_TIMESTAMP(%s)
     """
     LEAK_COUNT = """
-    SELECT COUNT(*) FROM {table} WHERE item_timestamp < TO_TIMESTAMP({timestamp})
+    SELECT COUNT(*) FROM {table} WHERE item_timestamp < TO_TIMESTAMP(%s)
     """
 
 
@@ -58,12 +69,32 @@ class PostgresBucket(AbstractBucket):
     pool: ConnectionPool
 
     def __init__(self, pool: ConnectionPool, table: str, rates: List[Rate]):
+        from psycopg import sql
+
         self._clock = PostgresClock(pool)
         self.table = table.lower()
         self.pool = pool
         assert rates
         self.rates = rates
         self._full_tbl = f"ratelimit___{self.table}"
+
+        # Compose all SQL with properly-quoted identifiers and bound
+        # parameters instead of f-string interpolation (issue #233). The table
+        # identifier is fixed per bucket, so the statements are composed once
+        # here; only values vary and are passed as query parameters.
+        tbl = sql.Identifier(self._full_tbl)
+        index_name = sql.Identifier(f"timestampindex_{self.table}")
+        self._q_create_table = sql.SQL(Queries.CREATE_BUCKET_TABLE).format(table=tbl)
+        self._q_create_index = sql.SQL(Queries.CREATE_INDEX_ON_TIMESTAMP).format(index=index_name, table=tbl)
+        self._q_lock = sql.SQL(Queries.LOCK_TABLE).format(table=tbl)
+        self._q_count = sql.SQL(Queries.COUNT).format(table=tbl)
+        self._q_count_window = sql.SQL(Queries.COUNT_WINDOW).format(table=tbl)
+        self._q_put = sql.SQL(Queries.PUT).format(table=tbl)
+        self._q_flush = sql.SQL(Queries.FLUSH).format(table=tbl)
+        self._q_peek = sql.SQL(Queries.PEEK).format(table=tbl)
+        self._q_leak = sql.SQL(Queries.LEAK).format(table=tbl)
+        self._q_leak_count = sql.SQL(Queries.LEAK_COUNT).format(table=tbl)
+
         self._create_table()
 
     @contextmanager
@@ -75,9 +106,8 @@ class PostgresBucket(AbstractBucket):
         with self._get_conn() as conn:
             lock_id = hash(self._full_tbl) & 0x7FFFFFFF
             conn.execute("SELECT pg_advisory_xact_lock(%s)", (lock_id,))
-            conn.execute(Queries.CREATE_BUCKET_TABLE.format(table=self._full_tbl))
-            index_name = f"timestampIndex_{self.table}"
-            conn.execute(Queries.CREATE_INDEX_ON_TIMESTAMP.format(table=self._full_tbl, index=index_name))
+            conn.execute(self._q_create_table)
+            conn.execute(self._q_create_index)
 
     def put(self, item: RateItem) -> Union[bool, Awaitable[bool]]:
         """Put an item (typically the current time) in the bucket
@@ -103,18 +133,14 @@ class PostgresBucket(AbstractBucket):
             # throughput under high contention since only one writer can perform
             # the check-and-put at a time.
             try:
-                conn.execute(Queries.LOCK_TABLE.format(table=self._full_tbl))
+                conn.execute(self._q_lock)
             except LockNotAvailable:
                 logger.debug("LockNotAvailable")
                 self.failing_rate = self.rates[0]
                 return False
 
             for rate in self.rates:
-                cur = conn.execute(
-                    f"SELECT COUNT(*) FROM {self._full_tbl} "  # noqa: S608
-                    f"WHERE item_timestamp >= TO_TIMESTAMP(%s) - (%s * INTERVAL '1 milliseconds')",
-                    (item_ts_seconds, rate.interval),
-                )
+                cur = conn.execute(self._q_count_window, (item_ts_seconds, rate.interval))
                 count = int(cur.fetchone()[0])
                 cur.close()
 
@@ -123,9 +149,8 @@ class PostgresBucket(AbstractBucket):
                     return False
 
             self.failing_rate = None
-            query = Queries.PUT.format(table=self._full_tbl)
             for _ in range(item.weight):
-                conn.execute(query, (item.name, item.weight, item_ts_seconds))
+                conn.execute(self._q_put, (item.name, item.weight, item_ts_seconds))
 
         return True
 
@@ -141,13 +166,14 @@ class PostgresBucket(AbstractBucket):
             return 0
 
         count = 0
+        lower_bound_seconds = lower_bound / 1000
 
         with self._get_conn() as conn:
-            conn = conn.execute(Queries.LEAK_COUNT.format(table=self._full_tbl, timestamp=lower_bound / 1000))
-            result = conn.fetchone()
+            cur = conn.execute(self._q_leak_count, (lower_bound_seconds,))
+            result = cur.fetchone()
 
             if result:
-                conn.execute(Queries.LEAK.format(table=self._full_tbl, timestamp=lower_bound / 1000))
+                conn.execute(self._q_leak, (lower_bound_seconds,))
                 count = int(result[0])
 
         return count
@@ -157,7 +183,7 @@ class PostgresBucket(AbstractBucket):
         - Must remove `failing-rate` after flushing
         """
         with self._get_conn() as conn:
-            conn.execute(Queries.FLUSH.format(table=self._full_tbl))
+            conn.execute(self._q_flush)
             self.failing_rate = None
 
         return None
@@ -166,8 +192,8 @@ class PostgresBucket(AbstractBucket):
         """Count number of items in the bucket"""
         count = 0
         with self._get_conn() as conn:
-            conn = conn.execute(Queries.COUNT.format(table=self._full_tbl))
-            result = conn.fetchone()
+            cur = conn.execute(self._q_count)
+            result = cur.fetchone()
             assert result
             count = int(result[0])
 
@@ -181,8 +207,8 @@ class PostgresBucket(AbstractBucket):
         item = None
 
         with self._get_conn() as conn:
-            conn = conn.execute(Queries.PEEK.format(table=self._full_tbl, offset=index))
-            result = conn.fetchone()
+            cur = conn.execute(self._q_peek, (index,))
+            result = cur.fetchone()
             if result:
                 name, weight, timestamp = result[0], int(result[1]), int(result[2])
                 item = RateItem(name=name, weight=weight, timestamp=timestamp)

--- a/tests/test_postgres_concurrent.py
+++ b/tests/test_postgres_concurrent.py
@@ -32,6 +32,30 @@ class TestPostgresConcurrent:
         with pg_pool.connection() as conn:
             conn.execute(f"DROP TABLE IF EXISTS ratelimit___{table}")
 
+    def test_table_name_requiring_quoting(self, pg_pool):
+        """A table name that is not a bare SQL identifier (e.g. contains a
+        hyphen or mixed case) must be handled via proper identifier quoting,
+        not raw f-string interpolation (issue #233)."""
+        from pyrate_limiter import id_generator
+
+        raw = f"weird-Name {id_generator()}"
+        bucket = PostgresBucket(pg_pool, raw, [Rate(5, Duration.SECOND)])
+        try:
+            assert bucket.count() == 0
+            ts = bucket.now()
+            assert bucket.put(RateItem("x", ts, weight=1)) is True
+            assert bucket.count() == 1
+            assert bucket.leak(ts + Duration.SECOND * 10) == 1
+            bucket.flush()
+            assert bucket.count() == 0
+        finally:
+            from psycopg import sql
+
+            with pg_pool.connection() as conn:
+                conn.execute(
+                    sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(bucket._full_tbl))
+                )
+
     def test_concurrent_put(self, pg_pool, clean_table):
         rate_limit = 5
         rates = [Rate(rate_limit, Duration.SECOND)]


### PR DESCRIPTION
## Summary

Closes #233.

`PostgresBucket` built every statement by interpolating the table name (and, for `leak`/`peek`, raw values) into the SQL string via f-strings / `str.format`, suppressed with `# noqa: S608`. Beyond the lint suppression, any table name that isn't a bare SQL identifier — a hyphen, a space, mixed case, a reserved word — produced a syntax error (and an injection surface for untrusted table names).

Repro on `master`:
```python
PostgresBucket(pool, "weird-name", [Rate(5, 1000)])
# psycopg.errors.SyntaxError: syntax error at or near "-"
```

## Fix

Compose all statements **once in `__init__`** using:
- `psycopg.sql.Identifier(...)` for the table and index names (proper quoting), and
- bound `%s` parameters for all values (timestamps, offsets).

The table identifier is fixed per bucket, so the composed statements are built a single time and reused across calls. The windowed-count query that was an inline f-string in `put()` is now a named `Queries.COUNT_WINDOW` template.

The public `PgQueries` (`Queries`) class is **kept as plain-string templates** — this preserves the optional `psycopg` import (the module still imports without psycopg installed) and the public API surface. Value placeholders that were `{offset}`/`{timestamp}` are now `%s`.

All `# noqa: S608` suppressions are removed.

## Testing

- New test `test_table_name_requiring_quoting` (table name with hyphen, space, mixed case) — fails on `master` with the syntax error above, passes here. Exercises `count`/`put`/`leak`/`flush`.
- Full Postgres suite green against Postgres: **13 postgres tests pass** (`test_postgres_concurrent.py` + parametrized `test_bucket_all.py` / `test_bucket_factory.py`).
- `nox -e lint` (ruff incl. the S608 rule + mypy) passes with no suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)