### PR TITLE
fix: SQLite injection via item name + leak-after-close race (#244)

### DIFF
--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -31,7 +31,7 @@ class Queries:
     WHERE item_timestamp >= :current_timestamp - :interval{index}
     """
     PUT_ITEM = """
-    INSERT INTO '{table}' (name, item_timestamp) VALUES %s
+    INSERT INTO '{table}' (name, item_timestamp) VALUES (?, ?)
     """
     LEAK = """
     DELETE FROM "{table}" WHERE rowid IN (
@@ -122,15 +122,22 @@ class SQLiteBucket(AbstractBucket):
                     self.failing_rate = rate
                     return False
 
-            items = ", ".join([f"('{name}', {item.timestamp})" for name in [item.name] * item.weight])
-            query = (Queries.PUT_ITEM.format(table=self.table)) % items
-            self.conn.execute(query).close()
+            # Bind name + timestamp as parameters; never interpolate the
+            # user-supplied name into SQL (injection / quote-crash).
+            query = Queries.PUT_ITEM.format(table=self.table)
+            rows = [(item.name, item.timestamp)] * item.weight
+            self.conn.executemany(query, rows)
             self.conn.commit()
             return True
 
     def leak(self, current_timestamp: Optional[int] = None) -> int:
         """Leaking/clean up bucket"""
         with self.lock:
+            if self.conn is None:
+                # The background Leaker may call leak() after close() has
+                # dropped the connection during teardown (issue #244).
+                return 0
+
             assert current_timestamp is not None
             query = Queries.COUNT_BEFORE_LEAK.format(
                 table=self.table,

--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -126,7 +126,7 @@ class SQLiteBucket(AbstractBucket):
             # user-supplied name into SQL (injection / quote-crash).
             query = Queries.PUT_ITEM.format(table=self.table)
             rows = [(item.name, item.timestamp)] * item.weight
-            self.conn.executemany(query, rows)
+            self.conn.executemany(query, rows).close()
             self.conn.commit()
             return True
 

--- a/tests/test_sqlite_bucket.py
+++ b/tests/test_sqlite_bucket.py
@@ -1,0 +1,48 @@
+"""Focused unit tests for SQLiteBucket edge cases."""
+from pathlib import Path
+from tempfile import gettempdir
+
+import pytest
+
+from pyrate_limiter import Duration, Rate, RateItem, SQLiteBucket, id_generator
+
+
+def _make_bucket(rates):
+    db_path = str(Path(gettempdir()) / f"pyrate_sqlite_test_{id_generator()}.sqlite")
+    table = f"pyrate-test-{id_generator()}"
+    return SQLiteBucket.init_from_file(rates, db_path=db_path, table=table, create_new_table=True)
+
+
+@pytest.mark.sqlite
+def test_sqlite_put_name_with_sql_metacharacters():
+    """Bucket names are user-supplied (``try_acquire(name=...)``) and must be
+    bound as parameters, not interpolated into SQL. A name containing a single
+    quote previously crashed `put`, and a crafted name was an injection vector."""
+    bucket = _make_bucket([Rate(100, Duration.SECOND)])
+    try:
+        name = "user's-key"
+        assert bucket.put(RateItem(name, bucket.now(), weight=1)) is True
+        assert bucket.count() == 1
+
+        item = bucket.peek(0)
+        assert item is not None
+        assert item.name == name  # round-trips intact
+
+        # An injection attempt must be stored as plain data, not executed.
+        evil = "x', 1); DROP TABLE foo; --"
+        assert bucket.put(RateItem(evil, bucket.now(), weight=2)) is True
+        assert bucket.count() == 3  # 1 + weight(2)
+    finally:
+        bucket.close()
+
+
+@pytest.mark.sqlite
+def test_sqlite_leak_after_close_is_safe():
+    """The background Leaker can call leak() during/after teardown; it must not
+    crash on a closed (None) connection (issue #244)."""
+    bucket = _make_bucket([Rate(100, Duration.SECOND)])
+    bucket.put(RateItem("x", bucket.now(), weight=1))
+    bucket.close()
+
+    # Previously raised AttributeError: 'NoneType' object has no attribute 'execute'
+    assert bucket.leak(bucket.now() + Duration.SECOND * 10) == 0


### PR DESCRIPTION
## Summary

Two `SQLiteBucket` bugs, both in the same file.

### 1. SQL injection / crash via the bucket name (security)

`put` built the INSERT by interpolating the item **name** inside quotes:
```python
items = ", ".join([f"('{name}', {item.timestamp})" for name in [item.name] * item.weight])
query = (Queries.PUT_ITEM.format(table=self.table)) % items
```
The name is the user-supplied key from `try_acquire(name=...)`. An ordinary name with an apostrophe crashed it, and a crafted name was an injection vector:
```
RateItem("user's-key") -> sqlite3.OperationalError: near "s": syntax error
```
This is the SQLite sibling of #233, and arguably worse — `name` is user-controlled and runs on every `put` (the count query already used bound params; only `PUT_ITEM` was unsafe).

**Fix:** bind name + timestamp as parameters via `executemany(query, rows)`; `PUT_ITEM` now uses `VALUES (?, ?)`.

### 2. leak-after-close race (closes #244)

`close()` sets `self.conn = None`, but the background `Leaker` thread can still call `leak()` → `self.conn.execute(...)`:
```
AttributeError: 'NoneType' object has no attribute 'execute'  (sqlite_bucket.py:140)
```
This is the source of the unstable `test_sqlite_filelock_bucket` thread-exception warning. **Fix:** `leak()` returns `0` when the connection is already closed.

## Testing

- New `tests/test_sqlite_bucket.py` with two tests — both fail on `master` (syntax error; `AttributeError`) and pass here.
  - `test_sqlite_put_name_with_sql_metacharacters` — apostrophe + injection-string names are stored as plain data and round-trip via `peek`.
  - `test_sqlite_leak_after_close_is_safe` — `leak()` after `close()` returns 0, no crash.
- Full SQLite/in-memory/mp suite: **65 passed, 1 skipped**, and the previous teardown warning is gone.
- `nox -e lint` (ruff + mypy) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)