### PR TITLE
fix: blocking-acquire boundary busy-spin + async timeout=0

### DIFF
--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -103,7 +103,12 @@ class AbstractBucket(ABC):
             assert self.failing_rate is not None  # NOTE: silence mypy
             lower_time_bound = item.timestamp - self.failing_rate.interval
             upper_time_bound = inner_bound_item.timestamp
-            return upper_time_bound - lower_time_bound
+            # +1: the window lower bound is inclusive across all backends (an
+            # item counts while timestamp >= now - interval). Returning the bare
+            # difference lands the retry exactly ON the boundary, where the item
+            # is still counted, so the re-put fails and waiting() then returns 0
+            # -> _delay_waiter busy-spins. One extra ms pushes strictly past it.
+            return upper_time_bound - lower_time_bound + 1
 
         async def _calc_waiting_async() -> int:
             nonlocal bound_item

--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -347,8 +347,8 @@ class Limiter:
 
         return _resolve_result(result)
 
-    async def _acquire_async(self, blocking, name, weight):
-        return await self._handle_async_result(self._try_acquire(name, weight, blocking=blocking, _force_async=True))
+    async def _acquire_async(self, blocking, name, weight, timeout=-1):
+        return await self._handle_async_result(self._try_acquire(name, weight, blocking=blocking, timeout=timeout, _force_async=True))
 
     async def try_acquire_async(self, name: str = "pyrate", weight: int = 1, blocking: bool = True, timeout: int | float = -1) -> bool:
         """
@@ -389,13 +389,18 @@ class Limiter:
         async def run():
             lock = self._get_async_lock()
             async with lock:
-                return await self._acquire_async(blocking=blocking, name=name, weight=weight)
+                # Pass timeout through so the internal deadline governs the wait
+                # (mirrors sync try_acquire). This makes timeout=0 a non-waiting
+                # attempt instead of asyncio.wait_for(timeout=0) failing before
+                # the acquire can even run.
+                return await self._acquire_async(blocking=blocking, name=name, weight=weight, timeout=timeout)
 
-        if timeout == -1:
-            return await run()
         try:
-            return await asyncio.wait_for(run(), timeout=timeout)
-        except asyncio.TimeoutError:
+            if timeout > 0:
+                # wait_for additionally bounds time spent waiting on the async lock.
+                return await asyncio.wait_for(run(), timeout=timeout)
+            return await run()
+        except (asyncio.TimeoutError, TimeoutError):
             return False
 
     async def _handle_async_acquire(

--- a/tests/test_acquire_path.py
+++ b/tests/test_acquire_path.py
@@ -1,0 +1,136 @@
+"""Characterization / regression tests for the Limiter acquire path
+(_delay_waiter / handle_bucket_put / _try_acquire) and AbstractBucket.waiting().
+
+These pin the (sync|async) x blocking x timeout x weight matrix of the
+highest-churn code in the library, using a deterministic InMemoryBucket.
+buffer_ms=0 is used deliberately so the leaky-bucket boundary math is tested
+honestly (the default buffer_ms=50 otherwise masks an off-by-one). Timing
+tolerances are generous to avoid flakiness.
+"""
+import time
+
+import pytest
+
+from pyrate_limiter import InMemoryBucket, Limiter, Rate, RateItem
+
+
+def _limiter(rates=None, buffer_ms=0):
+    return Limiter(InMemoryBucket(rates or [Rate(1, 100)]), buffer_ms=buffer_ms)
+
+
+# ------------------------------------------------- waiting() boundary (Bug X)
+
+def test_waiting_clears_inclusive_lower_bound():
+    """waiting() must return the delay to push an item PAST the inclusive
+    window lower bound. After sleeping exactly `waiting()`, a re-put must
+    succeed; otherwise _delay_waiter loops at delay=0 (busy-spin)."""
+    b = InMemoryBucket([Rate(1, 100)])
+    assert b.put(RateItem("a", 1000, weight=1)) is True
+    assert b.put(RateItem("b", 1000, weight=1)) is False  # full -> sets failing_rate
+
+    delay = b.waiting(RateItem("b", 1000))
+    assert isinstance(delay, int) and delay > 0
+    # Re-put after exactly `delay` must succeed (the freed item is out of window).
+    assert b.put(RateItem("b", 1000 + delay, weight=1)) is True
+
+
+# ---------------------------------------------------------------- weight == 0
+
+def test_weight_zero_sync_always_true_even_when_full():
+    lim = _limiter()
+    assert lim.try_acquire("k", weight=0) is True
+    assert lim.try_acquire("k") is True  # consume the only slot
+    assert lim.try_acquire("k", weight=0) is True
+    assert lim.try_acquire("k", weight=0, blocking=False) is True
+
+
+@pytest.mark.asyncio
+async def test_weight_zero_async_always_true_even_when_full():
+    lim = _limiter()
+    assert await lim.try_acquire_async("k", weight=0) is True
+    assert await lim.try_acquire_async("k") is True
+    assert await lim.try_acquire_async("k", weight=0) is True
+    assert await lim.try_acquire_async("k", weight=0, blocking=False) is True
+
+
+# ----------------------------------------------- input validation (async)
+
+@pytest.mark.asyncio
+async def test_async_nonblocking_with_timeout_raises():
+    lim = _limiter()
+    with pytest.raises(RuntimeError, match="Can't set timeout with non-blocking"):
+        await lim.try_acquire_async("k", blocking=False, timeout=0.1)
+
+
+# --------------------------------------------------------------- timeout == 0
+
+def test_timeout_zero_sync_succeeds_if_available_else_immediate_false():
+    lim = _limiter()
+    assert lim.try_acquire("k", blocking=True, timeout=0) is True
+    t0 = time.perf_counter()
+    ok = lim.try_acquire("k", blocking=True, timeout=0)
+    dt = time.perf_counter() - t0
+    assert ok is False
+    assert dt < 0.05
+
+
+@pytest.mark.asyncio
+async def test_timeout_zero_async_succeeds_if_available_else_immediate_false():
+    """Bug Y: try_acquire_async(timeout=0) must succeed when capacity is free
+    (it previously always returned False via asyncio.wait_for(timeout=0))."""
+    lim = _limiter([Rate(5, 100)])
+    assert await lim.try_acquire_async("k", blocking=True, timeout=0) is True
+    # Fill to the limit, then a timeout=0 acquire must fail immediately.
+    for _ in range(4):
+        assert await lim.try_acquire_async("k", blocking=True, timeout=0) is True
+    t0 = time.perf_counter()
+    ok = await lim.try_acquire_async("k", blocking=True, timeout=0)
+    dt = time.perf_counter() - t0
+    assert ok is False
+    assert dt < 0.05
+
+
+# ------------------------- blocking (no timeout) waits then OK, without spin
+
+def test_sync_blocking_succeeds_after_wait_without_spin():
+    lim = _limiter([Rate(1, 100)])
+    assert lim.try_acquire("k") is True
+    t0 = time.perf_counter()
+    assert lim.try_acquire("k") is True  # waits ~interval, then succeeds
+    dt = time.perf_counter() - t0
+    assert dt >= 0.05          # actually waited
+    assert dt < 1.0            # did NOT busy-spin to the background leaker (~10s)
+
+
+@pytest.mark.asyncio
+async def test_async_blocking_succeeds_after_wait_without_spin():
+    lim = _limiter([Rate(1, 100)])
+    assert await lim.try_acquire_async("k") is True
+    t0 = time.perf_counter()
+    assert await lim.try_acquire_async("k") is True
+    dt = time.perf_counter() - t0
+    assert dt >= 0.05
+    assert dt < 1.0
+
+
+# ------------------------------------ blocking + generous timeout: succeeds
+
+def test_sync_blocking_timeout_long_enough_succeeds():
+    lim = _limiter([Rate(1, 100)])
+    assert lim.try_acquire("k") is True
+    t0 = time.perf_counter()
+    ok = lim.try_acquire("k", blocking=True, timeout=1)  # 1s >> ~100ms wait
+    dt = time.perf_counter() - t0
+    assert ok is True
+    assert dt < 1.0  # succeeded well before the deadline
+
+
+@pytest.mark.asyncio
+async def test_async_blocking_timeout_long_enough_succeeds():
+    lim = _limiter([Rate(1, 100)])
+    assert await lim.try_acquire_async("k") is True
+    t0 = time.perf_counter()
+    ok = await lim.try_acquire_async("k", blocking=True, timeout=1)
+    dt = time.perf_counter() - t0
+    assert ok is True
+    assert dt < 1.0


### PR DESCRIPTION
## Summary

A characterization sweep over the core acquire path — `(sync|async)` × `blocking` × `timeout` × `weight` — surfaced **two latent bugs**. Both are in the highest-churn code in the library (`_delay_waiter` / `try_acquire_async` / `AbstractBucket.waiting()`), masked by the default `buffer_ms=50`.

### Bug 1 — `waiting()` off-by-one → busy-spin / spurious timeout

The window lower bound is **inclusive** across every backend (an item counts while `timestamp >= now − interval`). But `AbstractBucket.waiting()` returned the delay to land the retry *exactly on* that boundary — where the item is still counted. So after sleeping `waiting()`, the re-`put` fails by one unit and `waiting()` then returns `0`, leaving `_delay_waiter` spinning at `delay=0`.

Observed with `buffer_ms=0`:

| Case | Result | Elapsed |
|---|---|---|
| blocking, no timeout | True | **~10s** (CPU spin until the background leaker fires) |
| blocking, `timeout=1` | **False** | 1s (spurious — a slot frees after ~100ms) |
| (default `buffer_ms=50`) | True | ~155ms (masked) |

**Fix:** return `delay + 1` ms so the freed item falls strictly outside the inclusive window. `buffer_ms` then means only clock-drift slack again. One line in `_calc_waiting`; affects all backends.

### Bug 2 — `try_acquire_async(timeout=0)` always fails

It routed every `timeout != -1` through `asyncio.wait_for(run(), timeout=0)`, which fires before the (immediately satisfiable) acquire can run — so it returned `False` even on an empty bucket. Sync `try_acquire(timeout=0)` correctly returns `True`.

**Fix:** pass `timeout` through to the internal deadline (mirrors sync); use `wait_for` only as an outer bound for `timeout > 0`; catch both `asyncio.TimeoutError` and builtin `TimeoutError`.

## Tests

New `tests/test_acquire_path.py` characterizes the matrix and adds a **regression guard** that blocking-success does not busy-spin (asserts a `< 1s` upper bound with `buffer_ms=0`) — the old code took ~10s here. Also covers `weight=0`, `timeout=0` (sync+async), and async input validation.

## Coverage

Full-suite (all backends, services up) coverage measured locally at **90%**; this PR's changed lines are covered and the new tests exercise previously-untested branches, so coverage moves up, not down. Codecov will confirm on CI.

## Notes / out of scope

- A separate, pre-existing minor wart: when the **sync decorator rejects an async bucket**, `_cleanup_awaitable` closes the outer coroutine but not the inner one it captured (emits a `RuntimeWarning`). Not fixed here to keep scope tight — worth a follow-up.
- The larger `_delay_waiter` sync/async unification refactor is deliberately deferred; these two fixes shrink its surface first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)