### PR TITLE
docs: changelog for v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.3.0]
+
+Bug-fix and hardening release. It contains a few breaking changes that affect
+only edge or undocumented usage — see **Breaking Changes** below.
+
+### Breaking Changes
+- Ill-formed rate lists now raise `ValueError` at bucket construction instead
+  of being silently mis-enforced. A valid list is ordered by strictly
+  increasing interval, with strictly increasing limits and non-increasing
+  density (the "generous-before-tight" contract). (#239)
+- `binary_search` has been removed from the public API. It was an undocumented
+  internal helper, now replaced internally by the standard library `bisect`. (#290)
+- `PgQueries` SQL templates now use bound `%s` parameters instead of the
+  `{offset}` / `{timestamp}` format placeholders. (#233)
+
+### Security
+- SQLite and Postgres backends no longer build SQL through string
+  interpolation. The user-supplied item name (SQLite) and the table name
+  (Postgres) are now bound/quoted, closing a SQL-injection vector and fixing
+  crashes on names containing quotes or other metacharacters. (#233, #244)
+
+### Fixed
+- Blocking `try_acquire` no longer busy-spins (burning CPU until the next
+  background leak) or spuriously times out when `buffer_ms=0`; `waiting()` now
+  clears the inclusive window lower bound correctly. (#289)
+- `try_acquire_async(timeout=0)` now succeeds when capacity is available
+  instead of always returning `False`. (#289)
+- SQLite `leak()` no longer raises `AttributeError` when invoked on a closed
+  connection during teardown (fixes the unstable `test_sqlite_filelock_bucket`). (#244)
+- Rate lists are now consistently sorted by interval across all backends,
+  fixing a latent `leak()` bug when unsorted rates were passed to the Redis,
+  SQLite, or Postgres buckets. (#239)
+
+### Changed
+- Replaced the custom `binary_search` with the standard library `bisect`. (#290)
+
+### Documentation
+- Fixed stale v4 examples in the README (removed the long-gone `clock=`,
+  `raise_when_fail`, and `max_delay` parameters) and documented how to use a
+  custom / distributed clock in v4. (#261)
+
 ## [4.0.0]
 
 Fourth major release with significant API simplification and breaking changes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,90 @@
+# Release Workflow
+
+This document describes how to publish a new version of PyrateLimiter to PyPI.
+
+## Versioning
+
+PyrateLimiter uses [uv-dynamic-versioning](https://github.com/ninoseki/uv-dynamic-versioning) to derive the package version from **git tags**. There is no hardcoded version in `pyproject.toml` — the version is determined at build time from the most recent `v*` tag.
+
+## Prerequisites
+
+- Push access to the `master` branch
+- [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) configured on PyPI for this repository (one-time setup — see below)
+
+### One-time PyPI Trusted Publisher setup
+
+1. Go to https://pypi.org/manage/project/pyrate-limiter/settings/publishing/
+2. Add a new GitHub trusted publisher:
+   - **Owner:** `vutran1710`
+   - **Repository:** `PyrateLimiter`
+   - **Workflow name:** `build_test.yml`
+   - **Environment:** *(leave blank)*
+
+## Release steps
+
+### 1. Ensure `master` is up to date
+
+```shell
+git checkout master
+git pull origin master
+```
+
+### 2. Review changes since last release
+
+```shell
+git log $(git describe --tags --abbrev=0)..HEAD --oneline
+```
+
+### 3. Create and push a version tag
+
+Follow [Semantic Versioning](https://semver.org/):
+- **Patch** (v4.0.x): bug fixes, test improvements
+- **Minor** (v4.x.0): new features, backwards-compatible changes
+- **Major** (vX.0.0): breaking API changes
+
+```shell
+git tag v<VERSION>
+git push origin v<VERSION>
+```
+
+### 4. CI takes over
+
+Pushing a `v*` tag triggers the [build_test.yml](.github/workflows/build_test.yml) workflow which:
+
+1. **smoke** — lints and runs smoke tests
+2. **check-linux** — runs full test suite on Python 3.10, 3.14, 3.14t with Redis and Postgres services; builds the wheel on the latest Python
+3. **check-others** — runs tests on macOS and PyPy
+4. **publish** — downloads the built artifacts and publishes to PyPI via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+
+### 5. Create a GitHub Release
+
+After CI completes, create a GitHub Release and attach the build artifacts:
+
+```shell
+# Create release with auto-generated notes
+gh release create v<VERSION> --title "v<VERSION>" --generate-notes
+
+# Download CI-built artifacts and attach them
+gh run download <RUN_ID> --name dist --dir /tmp/pyrate-dist
+gh release upload v<VERSION> /tmp/pyrate-dist/*
+```
+
+To find the `<RUN_ID>`:
+
+```shell
+gh run list --limit 5
+```
+
+### 6. Update CHANGELOG.md
+
+Add an entry for the new version in `CHANGELOG.md` following the existing format.
+
+## Verifying the release
+
+```shell
+# Check PyPI
+pip install pyrate-limiter==<VERSION>
+
+# Check GitHub
+gh release view v<VERSION>
+```


### PR DESCRIPTION
Prep for the **v4.3.0** release. Adds the `[4.3.0]` CHANGELOG entry covering everything merged since v4.2.0 (#285, #286, #287, #288, #289, #290, #291) and commits the `RELEASING.md` runbook.

Once merged, the release proceeds by tagging `v4.3.0` on master (CI trusted-publishes to PyPI), with the locally-built wheel/sdist attached to the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)