### PR TITLE
refactor: dedupe _delay_waiter deadline math into a shared helper

### DIFF
--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -88,6 +88,25 @@ def combined_lock(locks: Union[Iterable[LockLike], RLock], blocking: bool, timeo
                 lock.release()
 
 
+def _plan_delay_step(deadline: Optional[float], delay_ms: Union[int, float]) -> Tuple[float, bool]:
+    """Plan one delay step for `_delay_waiter`.
+
+    Returns ``(seconds_to_sleep, raise_timeout_after_sleep)``. Raises
+    ``TimeoutError`` immediately (no sleep) when the deadline has already
+    passed. This is the deadline math shared verbatim by the sync and async
+    branches of `_delay_waiter`; the caller performs the actual sleep with its
+    own primitive (`time.sleep` vs `asyncio.sleep`) and re-raises afterwards.
+    """
+    if deadline is None:
+        return delay_ms / 1000, False
+    remaining_ms = (deadline - monotonic()) * 1000
+    if remaining_ms <= 0:
+        raise TimeoutError()
+    if remaining_ms < delay_ms:
+        return remaining_ms / 1000, True
+    return delay_ms / 1000, False
+
+
 class Limiter:
     """This class responsibility is to sum up all underlying logic
     and make working with async/sync functions easily
@@ -180,16 +199,10 @@ class Limiter:
                     assert d >= 0
                     d += self.buffer_ms
 
-                    if deadline is not None:
-                        remaining_ms = (deadline - monotonic()) * 1000
-                        if remaining_ms <= 0:
-                            raise TimeoutError()
-                        if remaining_ms < d:
-                            await asyncio.sleep(remaining_ms / 1000)
-                            raise TimeoutError()
-                        await asyncio.sleep(d / 1000)
-                    else:
-                        await asyncio.sleep(d / 1000)
+                    secs, timed_out = _plan_delay_step(deadline, d)
+                    await asyncio.sleep(secs)
+                    if timed_out:
+                        raise TimeoutError()
 
                     item.timestamp += d
                     r = bucket.put(item)
@@ -215,16 +228,10 @@ class Limiter:
                 delay += self.buffer_ms
                 total_delay += delay
 
-                if deadline is not None:
-                    remaining_ms = (deadline - monotonic()) * 1000
-                    if remaining_ms <= 0:
-                        raise TimeoutError()
-                    if remaining_ms < delay:
-                        sleep(remaining_ms / 1000)
-                        raise TimeoutError()
-                    sleep(delay / 1000)
-                else:
-                    sleep(delay / 1000)
+                secs, timed_out = _plan_delay_step(deadline, delay)
+                sleep(secs)
+                if timed_out:
+                    raise TimeoutError()
 
                 item.timestamp += delay
                 re_acquire = bucket.put(item)

--- a/tests/test_acquire_path.py
+++ b/tests/test_acquire_path.py
@@ -8,14 +8,39 @@ honestly (the default buffer_ms=50 otherwise masks an off-by-one). Timing
 tolerances are generous to avoid flakiness.
 """
 import time
+from inspect import isawaitable
 
 import pytest
 
-from pyrate_limiter import InMemoryBucket, Limiter, Rate, RateItem
+from pyrate_limiter import BucketAsyncWrapper, InMemoryBucket, Limiter, Rate, RateItem
 
 
 def _limiter(rates=None, buffer_ms=0):
     return Limiter(InMemoryBucket(rates or [Rate(1, 100)]), buffer_ms=buffer_ms)
+
+
+# ------------------------------------------- _plan_delay_step (shared helper)
+
+def test_plan_delay_step_outcomes():
+    """The deadline math shared by both _delay_waiter branches."""
+    from time import monotonic
+
+    from pyrate_limiter.limiter import _plan_delay_step
+
+    # No deadline -> sleep the full delay, never time out.
+    assert _plan_delay_step(None, 200) == (0.2, False)
+
+    # Deadline far in the future (remaining > delay) -> sleep the delay.
+    secs, timed_out = _plan_delay_step(monotonic() + 10, 200)
+    assert abs(secs - 0.2) < 0.02 and timed_out is False
+
+    # Deadline near (remaining < delay) -> sleep the remainder, then time out.
+    secs, timed_out = _plan_delay_step(monotonic() + 0.05, 200)
+    assert 0 < secs <= 0.07 and timed_out is True
+
+    # Deadline already passed -> raise immediately (no sleep).
+    with pytest.raises(TimeoutError):
+        _plan_delay_step(monotonic() - 1, 200)
 
 
 # ------------------------------------------------- waiting() boundary (Bug X)
@@ -134,3 +159,33 @@ async def test_async_blocking_timeout_long_enough_succeeds():
     dt = time.perf_counter() - t0
     assert ok is True
     assert dt < 1.0
+
+
+# --------------------------- async _delay_waiter branch under internal deadline
+
+@pytest.mark.asyncio
+async def test_async_delay_branch_times_out_mid_wait():
+    """An async bucket acquired via *sync* try_acquire(timeout=...) runs the
+    async _delay_waiter branch under the internal deadline (no asyncio.wait_for
+    wrapper). When the required wait exceeds the timeout, it sleeps up to the
+    deadline and resolves to False."""
+    lim = Limiter(BucketAsyncWrapper(InMemoryBucket([Rate(1, 500)])), buffer_ms=0)
+    assert await lim.try_acquire("k") is True  # consume the only slot
+
+    t0 = time.perf_counter()
+    res = lim.try_acquire("k", blocking=True, timeout=0.1)  # ~500ms wait > 0.1s timeout
+    assert isawaitable(res)
+    ok = await res
+    dt = time.perf_counter() - t0
+    assert ok is False
+    assert 0.05 <= dt <= 0.45
+
+
+@pytest.mark.asyncio
+async def test_async_delay_branch_succeeds_after_wait():
+    """Same async branch, but the timeout is generous: it sleeps then re-acquires."""
+    lim = Limiter(BucketAsyncWrapper(InMemoryBucket([Rate(1, 100)])), buffer_ms=0)
+    assert await lim.try_acquire("k") is True
+    res = lim.try_acquire("k", blocking=True, timeout=2)
+    assert isawaitable(res)
+    assert await res is True


### PR DESCRIPTION
A **surgical, behavior-preserving** cleanup of the hottest, most regression-prone code in the library — the blocking-acquire wait loop.

## What

The deadline → sleep/timeout decision was duplicated **verbatim** in both branches of `_delay_waiter` (the only difference being `asyncio.sleep` vs `time.sleep`). Extracted it into a pure helper:

```python
def _plan_delay_step(deadline, delay_ms) -> tuple[float, bool]:
    # (seconds_to_sleep, raise_timeout_after_sleep); raises TimeoutError if already past
```

Each branch now: `secs, timed_out = _plan_delay_step(...)` → sleep with its own primitive → re-raise if `timed_out`. ~20 lines of duplication → one tested helper.

## Behavior preserved (exactly)

The three outcomes are identical to before:
- deadline already past → raise `TimeoutError` immediately (no sleep)
- `remaining < delay` → sleep the remainder, then raise
- otherwise → sleep the full delay

The pre-existing async/sync asymmetry (async `assert d >= 0`; sync clamps negatives) is **left untouched** — not in scope for this surgical change.

## Tests added

- Characterization tests for the **async** `_delay_waiter` branch under the *internal* deadline — reached via a sync `try_acquire(timeout=...)` over a `BucketAsyncWrapper` bucket (no `asyncio.wait_for` wrapper), covering the previously-untested async timeout path.
- A direct unit test of `_plan_delay_step` pinning all four cases.

## Verification

- Acquire-path + blocking-timeout net: **green** (both sync & async branches)
- Full non-service suite: **143 passed, 1 skipped**
- **Live Redis** redis + asyncredis suite: **34 passed** — exercises the async branch with a real async bucket
- `nox -e lint` (ruff + mypy): clean

This was deliberately scoped *not* to attempt the larger sync/async path split — just to remove the duplication safely, now that #289/#291 added the characterization net around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)