### PR TITLE
perf: single multi-rate COUNT query for PostgresBucket

### DIFF
--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -89,7 +89,13 @@ class PostgresBucket(AbstractBucket):
         self._q_create_index = sql.SQL(Queries.CREATE_INDEX_ON_TIMESTAMP).format(index=index_name, table=tbl)
         self._q_lock = sql.SQL(Queries.LOCK_TABLE).format(table=tbl)
         self._q_count = sql.SQL(Queries.COUNT).format(table=tbl)
-        self._q_count_window = sql.SQL(Queries.COUNT_WINDOW).format(table=tbl)
+        # One scan computing every rate's windowed count via COUNT(*) FILTER,
+        # instead of one round trip per rate. Each rate contributes a
+        # (TO_TIMESTAMP(%s), %s) pair, filled in self.rates order at put time.
+        # Composed with psycopg.sql (no string interpolation).
+        _filter = sql.SQL("COUNT(*) FILTER (WHERE item_timestamp >= TO_TIMESTAMP(%s) - (%s * INTERVAL '1 milliseconds'))")
+        _fields = sql.SQL(", ").join([_filter] * len(self.rates))
+        self._q_count_windows = sql.SQL("SELECT {fields} FROM {table}").format(fields=_fields, table=tbl)
         self._q_put = sql.SQL(Queries.PUT).format(table=tbl)
         self._q_flush = sql.SQL(Queries.FLUSH).format(table=tbl)
         self._q_peek = sql.SQL(Queries.PEEK).format(table=tbl)
@@ -140,12 +146,13 @@ class PostgresBucket(AbstractBucket):
                 self.failing_rate = self.rates[0]
                 return False
 
-            for rate in self.rates:
-                cur = conn.execute(self._q_count_window, (item_ts_seconds, rate.interval))
-                count = int(cur.fetchone()[0])
-                cur.close()
+            params = [v for rate in self.rates for v in (item_ts_seconds, rate.interval)]
+            cur = conn.execute(self._q_count_windows, params)
+            counts = cur.fetchone()
+            cur.close()
 
-                if rate.limit - count < item.weight:
+            for rate, count in zip(self.rates, counts, strict=True):
+                if rate.limit - int(count) < item.weight:
                     self.failing_rate = rate
                     return False
 


### PR DESCRIPTION
## Summary

`PostgresBucket.put` ran **one COUNT round-trip per rate** while holding the `EXCLUSIVE` table lock (N rates = N round-trips under the lock). Compute all per-rate windowed counts in a **single scan** using `COUNT(*) FILTER (WHERE …)` — one per rate — composed entirely with `psycopg.sql` (no string interpolation, so no `# noqa: S608`).

This is item **#4** from the hot-path performance review.

## Correctness
Counts come back in `self.rates` order, so the loop still records the **first** failing rate — behavior is unchanged. Verified: multi-rate acceptance/rejection, the recorded `failing_rate`, and weighted rejection against the tightest rate.

## Measured
3-rate bucket, count step: **1.445 → 0.696 ms (~2.1×)** locally; fewer round-trips and shorter lock hold (helps multi-rate throughput, since the lock serializes writers).

## Verification
- 21 Postgres tests pass (live Postgres)
- `nox -e lint` (ruff incl. S608 + mypy): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)