### PR TITLE
revert: leaker threading loop (deadlocks free-threaded 3.14t)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ Performance and maintenance release. No API or behavior changes.
 - **PostgresBucket**: compute every rate's windowed count in one query
   (`COUNT(*) FILTER`) instead of one round trip per rate — ~2× faster
   multi-rate checks, fewer round trips under the lock. (#297)
-- **Leaker**: leak sync buckets on a plain thread loop instead of spinning up
-  an asyncio event loop; `close()` now stops the leaker promptly instead of
-  lagging up to a full leak interval. (#296)
 - **`SingleBucketFactory.wrap_item`**: inline the sync fast path (no
   per-acquire closures) — ~23% faster item wrapping on the hot path. (#296)
 - Deduplicate the sync/async deadline math in `_delay_waiter` into a single

--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -230,26 +230,11 @@ class Leaker(Thread):
             self.aio_leak_task = asyncio.create_task(self._leak(self.async_buckets))
 
     def run(self) -> None:
-        """Override Thread.run: periodically leak the sync buckets.
-
-        Sync buckets need no event loop, so this is a plain threading loop
-        rather than spinning up `asyncio.run` just to sleep. `_stop_event.wait`
-        makes the interval interruptible, so `close()` stops the thread
-        promptly instead of after up to a full interval. Not meant to be
-        called directly.
+        """Override the original method of Thread
+        Not meant to be called directly
         """
-        while not self._stop_event.is_set() and self.sync_buckets:
-            for _, bucket in tuple(self.sync_buckets.items()):
-                try:
-                    now = bucket.now()
-                    assert isinstance(now, int)
-                    bucket.leak(now)
-                except Exception as e:
-                    # A transient backend error (e.g. during teardown) must not
-                    # kill the daemon thread.
-                    logger.debug("Leak error for bucket %s: %s", id(bucket), e)
-            if self._stop_event.wait(self.leak_interval / 1000):
-                break
+        assert self.sync_buckets
+        asyncio.run(self._leak(self.sync_buckets))
 
     def start(self) -> None:
         """Override the original method of Thread


### PR DESCRIPTION
## Why

The leaker change from #296 (run the sync-bucket leaker on a `threading.Event.wait()` loop instead of `asyncio.run`) **intermittently deadlocked the free-threaded `3.14t` CI job** during the MultiprocessBucket tests — it blocked the v4.3.1 publish (hung 2/2 tag runs, >13 min each), while regular 3.10/3.14 passed.

**Mechanism:** a `multiprocessing` fork while the daemon leaker thread holds the `Event`'s internal lock leaves the forked child with a locked lock → deadlock (orphan child processes confirmed in the logs). Free-threaded 3.14t changes lock timing, which is why it surfaced only there.

## What

Restore the prior `asyncio`-based `run()` (`asyncio.run(self._leak(self.sync_buckets))`), which passed `3.14t` for v4.3.0 and in #294. The other #296 wins — **Postgres batched insert** and **`wrap_item` inline** — don't touch fork/threads and are retained. Removed the reverted leaker bullet from the v4.3.1 changelog.

(Net effect: we forgo the "no event loop + prompt shutdown" leaker tidy; correctness on free-threaded + multiprocessing wins.)

## Verification
- Leaker/multiprocessing tests (non-service): 22 passed
- `nox -e lint`: clean
- Full matrix incl. `3.14t` will be exercised on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)