### PR TITLE
fix: leaker/InMemory data race, Postgres clock fallback, leaker restart

### DIFF
--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -151,26 +151,32 @@ class AbstractBucket(ABC):
         self.close()
 
 
-class Leaker(Thread):
+class Leaker:
     """Responsible for scheduling buckets' leaking at the background either
-    through a daemon task(for sync buckets) or a task using asyncio.Task
+    through a daemon thread (for sync buckets) or a task using asyncio.Task.
+
+    The sync worker is an *encapsulated* daemon thread rather than ``self``
+    (this class used to subclass ``Thread``). A ``Thread`` can only be started
+    once, so when the worker exits after every sync bucket has been disposed,
+    re-registering a bucket and calling ``start()`` again would raise
+    ``RuntimeError: threads can only be started once`` (issue #301). Holding the
+    thread as an attribute lets ``start()`` spin up a fresh one on demand.
     """
 
-    daemon = True
     name = "PyrateLimiter's Leaker"
     sync_buckets: Dict[int, AbstractBucket]
     async_buckets: Dict[int, AbstractBucket]
     leak_interval: int = 10_000
     aio_leak_task: Optional[asyncio.Task] = None
     _stop_event: Any
+    _thread: Optional[Thread] = None
 
     def __init__(self, leak_interval: int):
         self.sync_buckets = defaultdict()
         self.async_buckets = defaultdict()
         self.leak_interval = leak_interval
         self._stop_event = Event()  # <--- add here
-
-        super().__init__()
+        self._thread = None
 
     def register(self, bucket: AbstractBucket):
         """Register a new bucket with its associated clock"""
@@ -229,19 +235,26 @@ class Leaker(Thread):
         if self.async_buckets and not self.aio_leak_task:
             self.aio_leak_task = asyncio.create_task(self._leak(self.async_buckets))
 
-    def run(self) -> None:
-        """Override the original method of Thread
-        Not meant to be called directly
-        """
+    def is_alive(self) -> bool:
+        """Whether the sync-leak worker thread is currently running."""
+        return self._thread is not None and self._thread.is_alive()
+
+    def _run(self) -> None:
+        """Worker-thread target; not meant to be called directly."""
         assert self.sync_buckets
         asyncio.run(self._leak(self.sync_buckets))
 
     def start(self) -> None:
-        """Override the original method of Thread
-        Call to run leaking sync buckets
+        """Start (or restart) the daemon thread that leaks sync buckets.
+
+        The worker exits once every sync bucket is disposed; a finished
+        ``Thread`` cannot be restarted, so we create a fresh one here instead of
+        re-starting the dead one (which would raise ``RuntimeError``).
         """
         if self.sync_buckets and not self.is_alive():
-            super().start()
+            self._stop_event.clear()
+            self._thread = Thread(target=self._run, name=self.name, daemon=True)
+            self._thread.start()
 
     def close(self):
         self._stop_event.set()

--- a/pyrate_limiter/buckets/in_memory_bucket.py
+++ b/pyrate_limiter/buckets/in_memory_bucket.py
@@ -2,6 +2,7 @@
 
 from bisect import bisect_left
 from operator import attrgetter
+from threading import RLock
 from typing import List, Optional
 
 from ..abstracts.bucket import AbstractBucket
@@ -28,67 +29,89 @@ class InMemoryBucket(AbstractBucket):
 
         self.rates = rates  # AbstractBucket.rates setter sorts + validates
         self.items = []
+        # Guards `self.items` against the background Leaker thread, which calls
+        # leak() WITHOUT holding the Limiter lock. Without this, leak()'s
+        # `del self.items[:idx]` can interleave with put()/peek() and corrupt
+        # window counts or raise IndexError (issue #300). RLock so the methods
+        # may call each other (peek -> count) re-entrantly.
+        self._lock = RLock()
 
     def put(self, item: RateItem) -> bool:
         if item.weight == 0:
             return True
 
-        current_length = len(self.items)
-        after_length = item.weight + current_length
+        with self._lock:
+            current_length = len(self.items)
+            after_length = item.weight + current_length
 
-        for rate in self.rates:
-            if after_length < rate.limit:
-                break
+            for rate in self.rates:
+                if after_length < rate.limit:
+                    break
 
-            lower_bound_value = item.timestamp - rate.interval
-            # First item still inside this rate's window (timestamp >= lower bound).
-            # When all items are older, bisect returns len(items) -> 0 in window.
-            lower_bound_idx = bisect_left(self.items, lower_bound_value, key=_by_timestamp)
-            count_existing_items = len(self.items) - lower_bound_idx
-            space_available = rate.limit - count_existing_items
+                lower_bound_value = item.timestamp - rate.interval
+                # First item still inside this rate's window (timestamp >= lower bound).
+                # When all items are older, bisect returns len(items) -> 0 in window.
+                lower_bound_idx = bisect_left(self.items, lower_bound_value, key=_by_timestamp)
+                count_existing_items = len(self.items) - lower_bound_idx
+                space_available = rate.limit - count_existing_items
 
-            if space_available < item.weight:
-                self.failing_rate = rate
-                return False
+                if space_available < item.weight:
+                    self.failing_rate = rate
+                    return False
 
-        self.failing_rate = None
+            self.failing_rate = None
 
-        if item.weight > 1:
-            self.items.extend([item for _ in range(item.weight)])
-        else:
-            self.items.append(item)
+            if item.weight > 1:
+                self.items.extend([item for _ in range(item.weight)])
+            else:
+                self.items.append(item)
 
-        return True
+            return True
 
     def leak(self, current_timestamp: Optional[int] = None) -> int:
         assert current_timestamp is not None
-        if self.items:
-            max_interval = self.rates[-1].interval
-            lower_bound = current_timestamp - max_interval
+        with self._lock:
+            if self.items:
+                max_interval = self.rates[-1].interval
+                lower_bound = current_timestamp - max_interval
 
-            if lower_bound > self.items[-1].timestamp:
-                remove_count = len(self.items)
-                del self.items[:]
-                return remove_count
+                if lower_bound > self.items[-1].timestamp:
+                    remove_count = len(self.items)
+                    del self.items[:]
+                    return remove_count
 
-            if lower_bound < self.items[0].timestamp:
-                return 0
+                if lower_bound < self.items[0].timestamp:
+                    return 0
 
-            idx = bisect_left(self.items, lower_bound, key=_by_timestamp)
-            del self.items[:idx]
-            return idx
+                idx = bisect_left(self.items, lower_bound, key=_by_timestamp)
+                del self.items[:idx]
+                return idx
 
-        return 0
+            return 0
 
     def flush(self) -> None:
-        self.failing_rate = None
-        del self.items[:]
+        with self._lock:
+            self.failing_rate = None
+            del self.items[:]
 
     def count(self) -> int:
-        return len(self.items)
+        with self._lock:
+            return len(self.items)
 
     def peek(self, index: int) -> RateItem | None:
-        if not self.items:
-            return None
+        with self._lock:
+            if not self.items:
+                return None
 
-        return self.items[-1 - index] if abs(index) < self.count() else None
+            return self.items[-1 - index] if abs(index) < self.count() else None
+
+    def __getstate__(self):
+        """A threading RLock can't be pickled; drop it and recreate on
+        unpickle so the Limiter stays picklable (issue #262)."""
+        state = self.__dict__.copy()
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._lock = RLock()

--- a/pyrate_limiter/buckets/mp_bucket.py
+++ b/pyrate_limiter/buckets/mp_bucket.py
@@ -25,6 +25,12 @@ class MultiprocessBucket(InMemoryBucket):
         self.rates = rates  # AbstractBucket.rates setter sorts + validates
         self.items = items
         self.mp_lock = mp_lock
+        # InMemoryBucket.put/peek/count/flush guard `self.items` via self._lock
+        # (issue #300). MultiprocessBucket does NOT call super().__init__(), so
+        # set it here. Aliasing it to the cross-process mp_lock means the
+        # inherited count()/peek()/flush() become process-safe too, and the
+        # reentrant RLock tolerates put()/leak() re-acquiring it via super().
+        self._lock = mp_lock
 
     def put(self, item: RateItem) -> bool:
         with self.mp_lock:
@@ -36,6 +42,13 @@ class MultiprocessBucket(InMemoryBucket):
 
     def limiter_lock(self):
         return self.mp_lock
+
+    def __setstate__(self, state):
+        # Re-alias _lock to the shared cross-process mp_lock rather than the
+        # thread-local RLock InMemoryBucket.__setstate__ would create, so the
+        # inherited count()/peek()/flush() stay tied to mp_lock across processes.
+        self.__dict__.update(state)
+        self._lock = self.mp_lock
 
     @classmethod
     def init(

--- a/pyrate_limiter/buckets/mp_bucket.py
+++ b/pyrate_limiter/buckets/mp_bucket.py
@@ -30,7 +30,7 @@ class MultiprocessBucket(InMemoryBucket):
         # set it here. Aliasing it to the cross-process mp_lock means the
         # inherited count()/peek()/flush() become process-safe too, and the
         # reentrant RLock tolerates put()/leak() re-acquiring it via super().
-        self._lock = mp_lock
+        self._lock = mp_lock  # type: ignore[assignment]
 
     def put(self, item: RateItem) -> bool:
         with self.mp_lock:
@@ -48,7 +48,7 @@ class MultiprocessBucket(InMemoryBucket):
         # thread-local RLock InMemoryBucket.__setstate__ would create, so the
         # inherited count()/peek()/flush() stay tied to mp_lock across processes.
         self.__dict__.update(state)
-        self._lock = self.mp_lock
+        self._lock = self.mp_lock  # type: ignore[assignment]
 
     @classmethod
     def init(

--- a/pyrate_limiter/clocks.py
+++ b/pyrate_limiter/clocks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from time import monotonic_ns
+from time import monotonic_ns, time_ns
 from typing import TYPE_CHECKING, Awaitable, Union
 
 if TYPE_CHECKING:
@@ -24,6 +24,16 @@ class AbstractClock(ABC):
     def _get_monotonic_ms() -> int:
         """Get monotonic time in milliseconds"""
         return monotonic_ns() // 1_000_000
+
+    @staticmethod
+    def _get_wall_ms() -> int:
+        """Get wall-clock (epoch) time in milliseconds.
+
+        Used as the local fallback for clocks whose stored timestamps are
+        wall-clock epoch ms (e.g. PostgresClock); must NOT be monotonic, which
+        is on an unrelated, far smaller scale.
+        """
+        return time_ns() // 1_000_000
 
 
 class MonotonicClock(AbstractClock):
@@ -73,5 +83,9 @@ class PostgresClock(AbstractClock):
         except Exception:
             logger.exception("Postgres time query failed, falling back to local clock")
 
-        # fallback to local monotonic time in milliseconds
-        return self._get_monotonic_ms()
+        # Fall back to local WALL-CLOCK epoch time in milliseconds - NOT
+        # monotonic. Stored item timestamps are wall-clock epoch ms (the bucket
+        # writes TO_TIMESTAMP(now/1000)); monotonic_ns() is seconds-since-boot,
+        # ~5 orders of magnitude smaller, so mixing it with epoch timestamps in
+        # the same bucket would corrupt every window comparison and leak bound.
+        return self._get_wall_ms()

--- a/tests/test_clocks.py
+++ b/tests/test_clocks.py
@@ -126,9 +126,10 @@ def test_postgres_clock_fallback_to_local_on_exception(monkeypatch):
 
     expected_ms = 1_234_567_890_000
 
-    # patch the clocks._get_monotonic_ms used in PostgresClock fallback
+    # patch the clocks._get_wall_ms used in PostgresClock fallback (wall-clock
+    # epoch ms, matching the bucket's stored timestamps - not monotonic)
     monkeypatch.setattr(
-        "pyrate_limiter.clocks.AbstractClock._get_monotonic_ms",
+        "pyrate_limiter.clocks.AbstractClock._get_wall_ms",
         staticmethod(lambda: expected_ms),
     )
 
@@ -182,7 +183,7 @@ async def test_monotonic_async_clock_now_non_decreasing():
 
 def test_postgres_clock_no_rows_falls_back(monkeypatch):
     """If the Postgres time query returns no rows, the clock should
-    fall back to the local monotonic time (exercise the row is None branch).
+    fall back to the local wall-clock time (exercise the row is None branch).
     """
 
     class ConnNoRow:
@@ -201,9 +202,9 @@ def test_postgres_clock_no_rows_falls_back(monkeypatch):
 
     expected_ms = 9_000_000_000
 
-    # force the fallback monotonic value so the result is predictable
+    # force the fallback wall-clock value so the result is predictable
     monkeypatch.setattr(
-        "pyrate_limiter.clocks.AbstractClock._get_monotonic_ms",
+        "pyrate_limiter.clocks.AbstractClock._get_wall_ms",
         staticmethod(lambda: expected_ms),
     )
 


### PR DESCRIPTION
Backward-compatible correctness fixes (no public API change):

- InMemoryBucket: add an internal RLock guarding items in put/peek/
  count/flush/leak. The background Leaker thread calls leak() without
  holding the Limiter lock, so its `del self.items[:idx]` could
  interleave with put()/peek() and corrupt window counts or raise
  IndexError. MultiprocessBucket aliases _lock to its mp_lock so the
  inherited count/peek/flush become cross-process safe too.

- PostgresClock: fall back to wall-clock epoch ms (new _get_wall_ms
  helper) instead of monotonic time. Stored timestamps are wall-clock
  epoch ms; the monotonic fallback is ~5 orders of magnitude smaller
  and would corrupt every window comparison and leak bound on DB error.

- Leaker: encapsulate the sync worker thread instead of subclassing
  Thread, so it can be recreated after draining. A finished Thread
  cannot be restarted; re-registering a sync bucket previously raised
  "threads can only be started once".

- InMemoryBucket: exclude the RLock from pickling and recreate it on
  unpickle, keeping Limiter picklable.

https://claude.ai/code/session_01WDgwnj6c9HQoogmHi1QaQw