### PR TITLE
perf(limiter): release the limiter lock during the sync blocking wait (#301)

### DIFF
--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -282,34 +282,76 @@ class Limiter:
         self, bucket: AbstractBucket, item: RateItem, blocking: bool, _force_async: bool = False, deadline: Optional[float] = None
     ) -> Union[bool, Awaitable[bool]]:
         """Putting item into bucket"""
-
-        def _handle_result(is_success: bool):
-            if not is_success:
-                return self._delay_waiter(bucket, item, blocking=blocking, _force_async=_force_async, deadline=deadline)
-
-            return True
-
         acquire = bucket.put(item)
 
         if isawaitable(acquire):
+            return self._wait_after_async_put(bucket, item, acquire, blocking=blocking, deadline=deadline)
 
-            async def _put_async(acquire):
-                acquire_result = await self._handle_async_result(acquire, deadline=deadline)
-                if acquire_result:
+        if acquire:
+            return True
+
+        return self._delay_waiter(bucket, item, blocking=blocking, _force_async=_force_async, deadline=deadline)
+
+    async def _wait_after_async_put(self, bucket, item, acquire, blocking, deadline=None):
+        """Resolve an awaitable ``put`` result, then run the (async) delay loop
+        on failure.
+
+        Shared by ``handle_bucket_put``, the async-put branch of
+        ``_try_acquire``, and the rare "sync bucket returned an awaitable
+        mid-wait" case in ``_blocking_retry_sync``. The delay loop is always
+        forced async here because we are already inside a coroutine.
+        """
+        acquire_result = await self._handle_async_result(acquire, deadline=deadline)
+        if acquire_result:
+            return True
+
+        result = self._delay_waiter(bucket, item, blocking=blocking, _force_async=True, deadline=deadline)
+        return await self._handle_async_result(result, deadline=deadline)
+
+    def _blocking_retry_sync(
+        self, bucket: AbstractBucket, item: RateItem, wait_ms: int, blocking: bool, deadline: Optional[float] = None
+    ) -> Union[bool, Awaitable[bool]]:
+        """Sync blocking wait with the limiter lock RELEASED during the sleep.
+
+        The initial check-then-put already happened under the lock in
+        ``_try_acquire``; this loop sleeps WITHOUT the lock, then re-acquires it
+        only to re-put and recompute the wait. Because every ``put()`` +
+        ``waiting()`` pair runs inside a single lock hold, ``failing_rate`` stays
+        consistent; only the already-computed sleep duration spans the unlocked
+        window, and the loop re-checks on wake, so a stale duration costs at most
+        one extra retry - never correctness. Releasing the lock means a long
+        wait on one key no longer serializes acquisitions for other keys (#301).
+        """
+        while True:
+            sleep_ms = self._delay_to_sleep_ms(wait_ms)
+            if sleep_ms is None:
+                return False
+
+            secs, timed_out = _plan_delay_step(deadline, sleep_ms)
+            sleep(secs)  # lock intentionally NOT held during the sleep
+            if timed_out:
+                raise TimeoutError()
+
+            item.timestamp += sleep_ms
+            remaining: Union[int, float] = -1 if deadline is None else max(0.0, deadline - monotonic())
+
+            with combined_lock(self.lock, blocking=True, timeout=remaining):
+                re_acquire = bucket.put(item)
+
+                if isawaitable(re_acquire):
+                    # Pathological: a nominally-sync bucket returned an awaitable
+                    # mid-wait. Hand off to the async tail (lock released on return).
+                    return self._handle_async_result(
+                        self._wait_after_async_put(bucket, item, re_acquire, blocking=blocking, deadline=deadline),
+                        deadline=deadline,
+                    )
+
+                if re_acquire:
                     return True
 
-                result = self._delay_waiter(
-                    bucket,
-                    item,
-                    blocking=blocking,
-                    _force_async=True,
-                    deadline=deadline,
-                )
-                return await self._handle_async_result(result, deadline=deadline)
-
-            return _put_async(acquire)
-
-        return _handle_result(acquire)  # type: ignore
+                next_wait = bucket.waiting(item)
+                assert isinstance(next_wait, int)
+                wait_ms = next_wait
 
     def _get_async_lock(self):
         """Returns thread_local, loop-specific lock"""
@@ -560,15 +602,42 @@ class Limiter:
             ):
                 raise RuntimeError("Can't use async bucket with sync decorator")
 
-            result = self.handle_bucket_put(bucket, item, blocking=blocking, _force_async=_force_async, deadline=deadline)
+            acquire = bucket.put(item)
 
-            if isawaitable(result):
+            if isawaitable(acquire):
                 if not _force_async and not _allow_async_result:
-                    self._cleanup_awaitable(result)
+                    self._cleanup_awaitable(acquire)
                     raise RuntimeError("Can't use async bucket with sync decorator")
+                return self._handle_async_result(
+                    self._wait_after_async_put(bucket, item, acquire, blocking=blocking, deadline=deadline),
+                    deadline=deadline,
+                )
+
+            if acquire:
+                return True
+
+            if not blocking:
+                return False
+
+            if _force_async:
+                # Async caller (try_acquire_async) over a sync bucket: keep the
+                # async delay loop (asyncio.sleep). The coroutine runs after this
+                # `with` exits, so the lock is not held during the wait anyway.
+                result = self._delay_waiter(bucket, item, blocking=blocking, _force_async=True, deadline=deadline)
                 return self._handle_async_result(result, deadline=deadline)
 
-            return result
+            # Sync caller: the first put failed and we will block. Capture the
+            # wait here (failing_rate is consistent under the lock), then leave
+            # the lock so the blocking sleep does not serialize other keys (#301).
+            wait_ms = bucket.waiting(item)
+            if isawaitable(wait_ms):
+                # Defensive parity with the old sync path: a bucket with a sync
+                # put() but an async waiting(). Fall back to the async delay loop.
+                result = self._delay_waiter(bucket, item, blocking=blocking, _force_async=True, deadline=deadline)
+                return self._handle_async_result(result, deadline=deadline)
+            assert isinstance(wait_ms, int)
+
+        return self._blocking_retry_sync(bucket, item, wait_ms, blocking=blocking, deadline=deadline)
 
     def as_decorator(self, *, name="ratelimiter", weight=1):
         def deco(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/tests/test_lock_release.py
+++ b/tests/test_lock_release.py
@@ -1,0 +1,58 @@
+"""Regression test for #301: the limiter lock must NOT be held during the
+sync blocking sleep, otherwise a long wait on one key serializes acquisitions
+for every other key sharing the limiter.
+"""
+import threading
+import time
+
+from pyrate_limiter import BucketFactory, InMemoryBucket, Limiter, Rate, RateItem
+from pyrate_limiter.clocks import MonotonicClock
+
+
+class _KeyedInMemoryFactory(BucketFactory):
+    """Minimal per-key factory: one InMemoryBucket per name, all sharing the
+    single limiter lock. No background leak (not needed for correctness)."""
+
+    def __init__(self, rates):
+        self._rates = rates
+        self._buckets: dict = {}
+        self._clock = MonotonicClock()
+
+    def wrap_item(self, name, weight=1):
+        return RateItem(name, self._clock.now(), weight=weight)
+
+    def get(self, item):
+        if item.name not in self._buckets:
+            self._buckets[item.name] = InMemoryBucket(list(self._rates))
+        return self._buckets[item.name]
+
+
+def test_blocking_wait_on_one_key_does_not_serialize_other_keys():
+    """While key 'A' is blocked waiting for its window, an acquire on the
+    unrelated key 'B' (with free capacity) must return promptly - i.e. the
+    limiter lock is released during A's sleep."""
+    limiter = Limiter(_KeyedInMemoryFactory([Rate(1, 400)]), buffer_ms=10)
+
+    assert limiter.try_acquire("A") is True  # consume A's only slot
+
+    started = threading.Event()
+
+    def block_on_a():
+        started.set()
+        assert limiter.try_acquire("A") is True  # full -> blocks ~400ms then ok
+
+    t = threading.Thread(target=block_on_a)
+    t.start()
+    started.wait()
+    time.sleep(0.05)  # let A's waiter reach its (unlocked) sleep
+
+    t0 = time.perf_counter()
+    assert limiter.try_acquire("B") is True  # B has free capacity
+    dt = time.perf_counter() - t0
+
+    # Lock released during A's sleep -> B is immediate. Before #301's fix B
+    # would block on the limiter lock until A's ~400ms wait elapsed.
+    assert dt < 0.15, f"B acquire took {dt:.3f}s - serialized behind A's wait?"
+
+    t.join(timeout=2)
+    assert not t.is_alive()


### PR DESCRIPTION
## Summary

Resolves #301. The sync blocking path held the limiter lock across the *entire* retry/sleep loop, so a long blocking wait on one key serialized acquisitions for **every** other key sharing the limiter. This releases the lock during the sleep.

**No public API change** — `try_acquire` / `try_acquire_async` / decorator signatures and semantics are unchanged.

## What changed

- `_try_acquire` now holds the lock only for item/bucket resolution and the **first** check-then-put. On a sync, blocking failure it captures the wait under the lock (so `failing_rate` is read consistently) and then leaves the lock.
- New `_blocking_retry_sync` sleeps **without** the lock and re-acquires it only to re-put and recompute the wait. Every `put()` + `waiting()` pair still runs inside a single lock hold, so `failing_rate` is never read across a release; only the already-computed sleep duration spans the unlocked window, and the loop re-checks on wake — a stale duration costs at most one extra retry, never correctness.
- `try_acquire_async` over a *sync* bucket still uses the async (`asyncio.sleep`) delay loop — only the genuinely-sync caller takes the new unlocked path, so the event loop is never blocked.
- Extracted `_wait_after_async_put`, shared by `handle_bucket_put`, the async-put branch of `_try_acquire`, and the rare "sync bucket returned an awaitable mid-wait" case.

## Why it's safe

`failing_rate` is per-bucket instance state read by `waiting()` immediately after the same thread's `put()`. Keeping each `put()`+`waiting()` inside one lock hold preserves that invariant; the only thing now outside the lock is the sleep itself.

## Testing

- New `tests/test_lock_release.py`: while key `A` is mid-wait (~400ms), an acquire on free key `B` returns in <0.15s. Before this change `B` would block on the limiter lock until `A`'s wait elapsed.
- Full non-external suite: **145 passed, 1 skipped**. `ruff check`, `ruff format --check`, and `mypy` (with `types-filelock`/`types-requests`/`types-redis`) all clean.
- ⚠️ Redis isn't installed in the local dev env, so the `asyncredis` backend path was not run here — please confirm that job is green in CI.

https://claude.ai/code/session_01WDgwnj6c9HQoogmHi1QaQw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDgwnj6c9HQoogmHi1QaQw)_