### PR TITLE
fix: declarative bucket is_async to drop side-effecting leak() probe (#305)

### DIFF
--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -26,6 +26,12 @@ class AbstractBucket(ABC):
     _rates: List[Rate]
     failing_rate: Optional[Rate] = None
     _clock: AbstractClock = MonotonicClock()
+    # Whether this bucket's operations return awaitables. ``None`` means
+    # "unknown" - the Leaker then probes once by calling ``leak(0)`` and
+    # checking for a coroutine. Built-in sync/async buckets declare this so no
+    # side-effecting probe is needed; ``RedisBucket`` leaves it ``None`` because
+    # it may wrap either a sync or an async client (issue #305).
+    is_async: Optional[bool] = None
 
     @property
     def rates(self) -> List[Rate]:
@@ -179,15 +185,26 @@ class Leaker:
         self._thread = None
 
     def register(self, bucket: AbstractBucket):
-        """Register a new bucket with its associated clock"""
+        """Register a new bucket, routing it to the sync or async leak loop.
+
+        Prefers the bucket's declared ``is_async``; only falls back to the
+        side-effecting ``leak(0)`` probe when that is ``None`` (issue #305).
+        """
         assert self.sync_buckets is not None
         assert self.async_buckets is not None
 
-        try_leak = bucket.leak(0)
         bucket_id = id(bucket)
+        is_async = bucket.is_async
 
-        if iscoroutine(try_leak):
-            try_leak.close()
+        if is_async is None:
+            try_leak = bucket.leak(0)
+            if iscoroutine(try_leak):
+                try_leak.close()
+                is_async = True
+            else:
+                is_async = False
+
+        if is_async:
             self.async_buckets[bucket_id] = bucket
         else:
             self.sync_buckets[bucket_id] = bucket

--- a/pyrate_limiter/abstracts/wrappers.py
+++ b/pyrate_limiter/abstracts/wrappers.py
@@ -12,6 +12,8 @@ class BucketAsyncWrapper(AbstractBucket):
     that turns a async/synchronous bucket into an async one
     """
 
+    is_async = True
+
     def __init__(self, bucket: AbstractBucket):
         assert isinstance(bucket, AbstractBucket)
         self.bucket = bucket

--- a/pyrate_limiter/buckets/in_memory_bucket.py
+++ b/pyrate_limiter/buckets/in_memory_bucket.py
@@ -23,6 +23,7 @@ class InMemoryBucket(AbstractBucket):
 
     items: List[RateItem]
     failing_rate: Optional[Rate]
+    is_async = False
 
     def __init__(self, rates: List[Rate]):
         super().__init__()

--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -66,6 +66,7 @@ class Queries:
 
 
 class PostgresBucket(AbstractBucket):
+    is_async = False
     table: str
     pool: ConnectionPool
 

--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -24,14 +24,10 @@ class LuaScript:
     local item_name = ARGV[3]
     local rates_count = tonumber(ARGV[4])
 
-    local max_interval = 0
     for i=1,rates_count do
         local offset = (i - 1) * 2
         local interval = tonumber(ARGV[5 + offset])
         local limit = tonumber(ARGV[5 + offset + 1])
-        if interval > max_interval then
-            max_interval = interval
-        end
         local count = redis.call('ZCOUNT', bucket, now - interval, now)
         local space_available = limit - tonumber(count)
         if space_available < space_required then
@@ -42,15 +38,6 @@ class LuaScript:
     for i=1,space_required do
         redis.call('ZADD', bucket, now, item_name..i)
     end
-
-    -- Self-expire fully-idle keys: by max_interval after the last write every
-    -- member is outdated anyway. Refreshed on each successful put, so active
-    -- keys never expire prematurely; idle ones no longer linger forever even
-    -- without the background leaker (issue #306).
-    if max_interval > 0 then
-        redis.call('PEXPIRE', bucket, max_interval)
-    end
-
     return -1
     """
 

--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -24,10 +24,14 @@ class LuaScript:
     local item_name = ARGV[3]
     local rates_count = tonumber(ARGV[4])
 
+    local max_interval = 0
     for i=1,rates_count do
         local offset = (i - 1) * 2
         local interval = tonumber(ARGV[5 + offset])
         local limit = tonumber(ARGV[5 + offset + 1])
+        if interval > max_interval then
+            max_interval = interval
+        end
         local count = redis.call('ZCOUNT', bucket, now - interval, now)
         local space_available = limit - tonumber(count)
         if space_available < space_required then
@@ -38,6 +42,15 @@ class LuaScript:
     for i=1,space_required do
         redis.call('ZADD', bucket, now, item_name..i)
     end
+
+    -- Self-expire fully-idle keys: by max_interval after the last write every
+    -- member is outdated anyway. Refreshed on each successful put, so active
+    -- keys never expire prematurely; idle ones no longer linger forever even
+    -- without the background leaker (issue #306).
+    if max_interval > 0 then
+        redis.call('PEXPIRE', bucket, max_interval)
+    end
+
     return -1
     """
 

--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -62,6 +62,7 @@ class SQLiteBucket(AbstractBucket):
     item's timestamp wont matter here
     """
 
+    is_async = False
     rates: List[Rate]
     failing_rate: Optional[Rate]
     conn: sqlite3.Connection

--- a/tests/test_leaker_async_detection.py
+++ b/tests/test_leaker_async_detection.py
@@ -27,11 +27,27 @@ class _ExplodingLeakAsync(InMemoryBucket):
         raise AssertionError("leak() must not be probed when is_async is declared")
 
 
-class _ProbedAsync(InMemoryBucket):
-    is_async = None  # force the probe fallback
+class _ProbedAsync(AbstractBucket):
+    """is_async left as the inherited None -> Leaker must fall back to probing
+    leak(0), which returns a coroutine and routes this to async."""
+
+    def __init__(self):
+        self.rates = RATES
+
+    async def put(self, item):
+        return True
 
     async def leak(self, current_timestamp=None):
         return 0
+
+    async def flush(self):
+        return None
+
+    async def count(self):
+        return 0
+
+    async def peek(self, index):
+        return None
 
 
 def test_declared_sync_registers_without_probing():
@@ -52,7 +68,7 @@ def test_declared_async_registers_without_probing():
 
 def test_unknown_falls_back_to_probe():
     leaker = Leaker(10_000)
-    bucket = _ProbedAsync(RATES)
+    bucket = _ProbedAsync()
     assert bucket.is_async is None
     leaker.register(bucket)  # probes leak(0) -> coroutine -> async
     assert id(bucket) in leaker.async_buckets

--- a/tests/test_leaker_async_detection.py
+++ b/tests/test_leaker_async_detection.py
@@ -1,0 +1,58 @@
+"""C5 (#305): the Leaker prefers a bucket's declared ``is_async`` and only
+falls back to the side-effecting ``leak(0)`` probe when it is ``None``.
+"""
+from pyrate_limiter import AbstractBucket, BucketAsyncWrapper, InMemoryBucket, Rate
+from pyrate_limiter.abstracts.bucket import Leaker
+
+RATES = [Rate(3, 1000)]
+
+
+def test_default_is_async_is_none_and_builtins_declare():
+    assert AbstractBucket.is_async is None  # unknown by default -> probe
+    assert InMemoryBucket(RATES).is_async is False
+    assert BucketAsyncWrapper(InMemoryBucket(RATES)).is_async is True
+
+
+class _ExplodingLeakSync(InMemoryBucket):
+    is_async = False
+
+    def leak(self, current_timestamp=None):  # pragma: no cover - must not run
+        raise AssertionError("leak() must not be probed when is_async is declared")
+
+
+class _ExplodingLeakAsync(InMemoryBucket):
+    is_async = True
+
+    def leak(self, current_timestamp=None):  # pragma: no cover - must not run
+        raise AssertionError("leak() must not be probed when is_async is declared")
+
+
+class _ProbedAsync(InMemoryBucket):
+    is_async = None  # force the probe fallback
+
+    async def leak(self, current_timestamp=None):
+        return 0
+
+
+def test_declared_sync_registers_without_probing():
+    leaker = Leaker(10_000)
+    bucket = _ExplodingLeakSync(RATES)
+    leaker.register(bucket)  # would raise if leak() were probed
+    assert id(bucket) in leaker.sync_buckets
+    assert id(bucket) not in leaker.async_buckets
+
+
+def test_declared_async_registers_without_probing():
+    leaker = Leaker(10_000)
+    bucket = _ExplodingLeakAsync(RATES)
+    leaker.register(bucket)  # would raise if leak() were probed
+    assert id(bucket) in leaker.async_buckets
+    assert id(bucket) not in leaker.sync_buckets
+
+
+def test_unknown_falls_back_to_probe():
+    leaker = Leaker(10_000)
+    bucket = _ProbedAsync(RATES)
+    assert bucket.is_async is None
+    leaker.register(bucket)  # probes leak(0) -> coroutine -> async
+    assert id(bucket) in leaker.async_buckets


### PR DESCRIPTION
## Summary

C5 (#305): the Leaker detected sync-vs-async by *executing* `leak(0)` on every registered bucket — a side-effecting probe. Add a declarative `is_async` class attribute (`None` = unknown → probe). Built-in buckets declare it (`InMemory`/`SQLite`/`Postgres` = False, `BucketAsyncWrapper` = True); `RedisBucket` leaves it `None` because it may wrap a sync OR async client, so it still probes. `register()` now only probes when `is_async` is `None`.

No public API change. Adds `tests/test_leaker_async_detection.py`.

## Deferred (not in this PR)

- **S3 (Redis key TTL, #306)** — added then reverted: a `PEXPIRE` on the bucket key expires it out from under `leak()`/`count()`, breaking `test_bucket_leak` (which sleeps past the window and expects `leak()` to still find/remove the outdated items and report the count). That's a contract conflict, not a tunable TTL value. Bounding idle Redis keys needs a different mechanism (leaker deleting drained keys, or a reaper) — deferred.
- **C4 (Postgres contention vs rate-exceeded)** — needs `put()` to signal contention distinctly from a rate breach, a breaking return-type change slated for v5.

https://claude.ai/code/session_01WDgwnj6c9HQoogmHi1QaQw