### PR TITLE
Add Redis performance and pressure benchmarks

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -149,6 +149,9 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: smoke
     runs-on: ubuntu-latest
+    env:
+      REDIS_CPU_LIMIT: "1"
+      REDIS_MEMORY_LIMIT: "512 MiB"
     services:
       redis:
         image: redis:7
@@ -159,6 +162,9 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 5
+          --cpuset-cpus 0
+          --memory 512m
+          --memory-swap 512m
     steps:
       - name: Check out PR merge commit
         uses: actions/checkout@v5
@@ -179,7 +185,7 @@ jobs:
           git worktree add --detach /tmp/pyrate-candidate ${{ github.event.pull_request.head.sha }}
       - name: Run Redis pressure benchmark
         run: |
-          uv run --group all python benchmarks/compare_redis_pressure.py \
+          taskset -c 1 uv run --group all python benchmarks/compare_redis_pressure.py \
             --baseline /tmp/pyrate-baseline \
             --candidate /tmp/pyrate-candidate \
             --json-output redis-pressure.json \

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -145,60 +145,6 @@ jobs:
           name: dist
           path: dist
 
-  redis-pressure:
-    if: github.event_name == 'pull_request'
-    needs: smoke
-    runs-on: ubuntu-latest
-    env:
-      REDIS_CPU_LIMIT: "1"
-      REDIS_MEMORY_LIMIT: "512 MiB"
-    services:
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 5
-          --cpuset-cpus 0
-          --memory 512m
-          --memory-swap 512m
-    steps:
-      - name: Check out PR merge commit
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Set up Python ${{ env.LATEST_PY_VERSION }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.LATEST_PY_VERSION }}
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          python-version: ${{ env.LATEST_PY_VERSION }}
-      - name: Prepare comparison checkouts
-        run: |
-          git worktree add --detach /tmp/pyrate-baseline ${{ github.event.pull_request.base.sha }}
-          git worktree add --detach /tmp/pyrate-candidate ${{ github.event.pull_request.head.sha }}
-      - name: Run Redis pressure benchmark
-        run: |
-          taskset -c 1 uv run --group all python benchmarks/compare_redis_pressure.py \
-            --baseline /tmp/pyrate-baseline \
-            --candidate /tmp/pyrate-candidate \
-            --json-output redis-pressure.json \
-            --markdown-output redis-pressure.md
-          cat redis-pressure.md >> "$GITHUB_STEP_SUMMARY"
-      - name: Upload Redis pressure results
-        uses: actions/upload-artifact@v6
-        with:
-          name: redis-pressure-${{ github.run_id }}
-          path: |
-            redis-pressure.json
-            redis-pressure.md
-
   publish:
     needs: [check-linux, check-others]
     runs-on: ubuntu-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -145,6 +145,54 @@ jobs:
           name: dist
           path: dist
 
+  redis-pressure:
+    if: github.event_name == 'pull_request'
+    needs: smoke
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - name: Check out PR merge commit
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ env.LATEST_PY_VERSION }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.LATEST_PY_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: ${{ env.LATEST_PY_VERSION }}
+      - name: Prepare comparison checkouts
+        run: |
+          git worktree add --detach /tmp/pyrate-baseline ${{ github.event.pull_request.base.sha }}
+          git worktree add --detach /tmp/pyrate-candidate ${{ github.event.pull_request.head.sha }}
+      - name: Run Redis pressure benchmark
+        run: |
+          uv run --group all python benchmarks/compare_redis_pressure.py \
+            --baseline /tmp/pyrate-baseline \
+            --candidate /tmp/pyrate-candidate \
+            --json-output redis-pressure.json \
+            --markdown-output redis-pressure.md
+          cat redis-pressure.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload Redis pressure results
+        uses: actions/upload-artifact@v6
+        with:
+          name: redis-pressure-${{ github.run_id }}
+          path: |
+            redis-pressure.json
+            redis-pressure.md
+
   publish:
     needs: [check-linux, check-others]
     runs-on: ubuntu-latest

--- a/.github/workflows/redis_pressure.yml
+++ b/.github/workflows/redis_pressure.yml
@@ -57,12 +57,11 @@ jobs:
           [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
           [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-      - name: Check out PR head
+      - name: Check out benchmark harness
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: refs/pull/${{ inputs.pr_number }}/head
       - name: Set up Python ${{ env.LATEST_PY_VERSION }}
         uses: actions/setup-python@v6
         with:
@@ -78,7 +77,8 @@ jobs:
           HEAD_SHA: ${{ inputs.head_sha }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git fetch --no-tags origin "refs/pull/$PR_NUMBER/head"
+          test "$(git rev-parse FETCH_HEAD)" = "$HEAD_SHA"
           git cat-file -e "$BASE_SHA^{commit}"
           git worktree add --detach /tmp/pyrate-baseline "$BASE_SHA"
           git worktree add --detach /tmp/pyrate-candidate "$HEAD_SHA"

--- a/.github/workflows/redis_pressure.yml
+++ b/.github/workflows/redis_pressure.yml
@@ -1,0 +1,102 @@
+name: Redis pressure benchmark
+
+run-name: Redis pressure PR #${{ inputs.pr_number }} at ${{ inputs.head_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+      base_sha:
+        description: Base commit SHA
+        required: true
+        type: string
+      head_sha:
+        description: Head commit SHA
+        required: true
+        type: string
+
+concurrency:
+  group: redis-pressure-pr-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  LATEST_PY_VERSION: "3.14"
+  REDIS: "redis://localhost:6379"
+  REDIS_CPU_LIMIT: "1"
+  REDIS_MEMORY_LIMIT: "512 MiB"
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+          --cpuset-cpus 0
+          --memory 512m
+          --memory-swap 512m
+    steps:
+      - name: Validate request
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
+          [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+      - name: Check out PR head
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: refs/pull/${{ inputs.pr_number }}/head
+      - name: Set up Python ${{ env.LATEST_PY_VERSION }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.LATEST_PY_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: ${{ env.LATEST_PY_VERSION }}
+      - name: Prepare comparison checkouts
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git cat-file -e "$BASE_SHA^{commit}"
+          git worktree add --detach /tmp/pyrate-baseline "$BASE_SHA"
+          git worktree add --detach /tmp/pyrate-candidate "$HEAD_SHA"
+          printf '%s\n' "$PR_NUMBER" > pr-number.txt
+      - name: Run Redis pressure benchmark
+        run: |
+          taskset -c 1 uv run --group all python benchmarks/compare_redis_pressure.py \
+            --baseline /tmp/pyrate-baseline \
+            --candidate /tmp/pyrate-candidate \
+            --json-output redis-pressure.json \
+            --markdown-output redis-pressure.md
+          cat redis-pressure.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload Redis pressure results
+        uses: actions/upload-artifact@v6
+        with:
+          name: redis-pressure-${{ github.run_id }}
+          retention-days: 30
+          path: |
+            pr-number.txt
+            redis-pressure.json
+            redis-pressure.md

--- a/.github/workflows/redis_pressure_comment.yml
+++ b/.github/workflows/redis_pressure_comment.yml
@@ -13,12 +13,13 @@ permissions:
 jobs:
   comment:
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.pull_requests[0] != null
     runs-on: ubuntu-latest
     steps:
       - name: Download benchmark report
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: redis-pressure-${{ github.event.workflow_run.id }}
@@ -26,6 +27,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
       - name: Update PR benchmark comment
+        if: steps.download.outcome == 'success'
         uses: actions/github-script@v8
         env:
           REPORT_PATH: benchmark-result/redis-pressure.md

--- a/.github/workflows/redis_pressure_comment.yml
+++ b/.github/workflows/redis_pressure_comment.yml
@@ -2,19 +2,18 @@ name: Publish Redis pressure results
 
 on:
   workflow_run:
-    workflows: ["Python package - UV"]
+    workflows: ["Redis pressure benchmark"]
     types: [completed]
 
 permissions:
   actions: read
   contents: read
-  pull-requests: write
+  issues: write
+  pull-requests: read
 
 jobs:
   comment:
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0] != null
+    if: github.event.workflow_run.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Download benchmark report
@@ -30,17 +29,36 @@ jobs:
         if: steps.download.outcome == 'success'
         uses: actions/github-script@v8
         env:
+          PR_NUMBER_PATH: benchmark-result/pr-number.txt
           REPORT_PATH: benchmark-result/redis-pressure.md
+          RESULT_PATH: benchmark-result/redis-pressure.json
         with:
           script: |
             const fs = require("fs");
             const marker = "<!-- redis-pressure-benchmark -->";
             const run = context.payload.workflow_run;
-            const pullRequest = run.pull_requests[0];
+            const prNumberText = fs.readFileSync(process.env.PR_NUMBER_PATH, "utf8").trim();
+            if (!/^\d+$/.test(prNumberText)) {
+              core.setFailed(`Invalid PR number in benchmark artifact: ${prNumberText}`);
+              return;
+            }
+            const pullRequestNumber = Number.parseInt(prNumberText, 10);
+            const result = JSON.parse(fs.readFileSync(process.env.RESULT_PATH, "utf8"));
             const report = fs
               .readFileSync(process.env.REPORT_PATH, "utf8")
               .trim()
               .replaceAll("@", "@\u200b");
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber,
+            });
+            if (pullRequest.head.sha !== result.candidate_commit) {
+              core.notice(
+                `Skipping stale result for ${result.candidate_commit}; PR head is ${pullRequest.head.sha}`,
+              );
+              return;
+            }
             const body = [
               marker,
               report,
@@ -57,7 +75,7 @@ jobs:
               {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: pullRequest.number,
+                issue_number: pullRequestNumber,
                 per_page: 100,
               },
             );
@@ -79,6 +97,6 @@ jobs:
             } else {
               await github.rest.issues.createComment({
                 ...request,
-                issue_number: pullRequest.number,
+                issue_number: pullRequestNumber,
               });
             }

--- a/.github/workflows/redis_pressure_comment.yml
+++ b/.github/workflows/redis_pressure_comment.yml
@@ -1,0 +1,82 @@
+name: Publish Redis pressure results
+
+on:
+  workflow_run:
+    workflows: ["Python package - UV"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0] != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark report
+        uses: actions/download-artifact@v8
+        with:
+          name: redis-pressure-${{ github.event.workflow_run.id }}
+          path: benchmark-result
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Update PR benchmark comment
+        uses: actions/github-script@v8
+        env:
+          REPORT_PATH: benchmark-result/redis-pressure.md
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- redis-pressure-benchmark -->";
+            const run = context.payload.workflow_run;
+            const pullRequest = run.pull_requests[0];
+            const report = fs
+              .readFileSync(process.env.REPORT_PATH, "utf8")
+              .trim()
+              .replaceAll("@", "@\u200b");
+            const body = [
+              marker,
+              report,
+              `[Benchmark workflow run](${run.html_url})`,
+            ].join("\n\n");
+
+            if (body.length > 65000) {
+              core.setFailed(`Benchmark comment is too large: ${body.length} characters`);
+              return;
+            }
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                per_page: 100,
+              },
+            );
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.type === "Bot" && comment.body?.includes(marker),
+            );
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            };
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...request,
+                comment_id: existing.id,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...request,
+                issue_number: pullRequest.number,
+              });
+            }

--- a/.github/workflows/redis_pressure_dispatch.yml
+++ b/.github/workflows/redis_pressure_dispatch.yml
@@ -1,0 +1,60 @@
+name: Dispatch Redis pressure benchmark
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch:
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/benchmark redis'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authorize and dispatch benchmark
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const username = context.payload.comment.user.login;
+            const { data: permission } =
+              await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username,
+              });
+            if (!["admin", "write"].includes(permission.permission)) {
+              core.setFailed(`${username} does not have permission to run benchmarks`);
+              return;
+            }
+
+            const pullRequestNumber = context.payload.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullRequestNumber,
+            });
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: "redis_pressure.yml",
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                pr_number: String(pullRequestNumber),
+                base_sha: pullRequest.base.sha,
+                head_sha: pullRequest.head.sha,
+              },
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: context.payload.comment.id,
+              content: "rocket",
+            });

--- a/benchmarks/compare_redis_pressure.py
+++ b/benchmarks/compare_redis_pressure.py
@@ -1,0 +1,565 @@
+"""Compare RedisBucket pressure between two source checkouts.
+
+Measures bucket growth and steady replacement while an independent connection
+samples PING latency. Use a dedicated Redis instance because CPU, network, and
+command statistics are server-wide.
+
+Example:
+    uv run --group all python benchmarks/compare_redis_pressure.py \
+        --baseline /tmp/pyrate-v4.3.0 \
+        --candidate /tmp/pyrate-v4.4.0 \
+        --redis-url redis://localhost:6379
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+from threading import Event, Thread
+from time import perf_counter, perf_counter_ns, sleep
+from typing import Any
+
+DEFAULT_ROUNDS = 5
+DEFAULT_SCENARIOS = [
+    ("second", 60),
+    ("minute", 1_000),
+    ("hour", 5_000),
+    ("day", 50_000),
+    ("month", 100_000),
+]
+WINDOWS_MS = {
+    "second": 1_000,
+    "minute": 60_000,
+    "hour": 3_600_000,
+    "day": 86_400_000,
+    "month": 2_592_000_000,
+}
+WORKLOADS = ("growth", "steady")
+
+
+def percentile_ns(values: list[int], fraction: float) -> float:
+    """Return a nearest-rank percentile in microseconds."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = max(0, math.ceil(len(ordered) * fraction) - 1)
+    return ordered[index] / 1_000
+
+
+def checkout_commit(checkout: Path) -> str:
+    """Return the checkout commit when it is a Git worktree."""
+    try:
+        return subprocess.check_output(  # noqa: S603
+            ["git", "-C", str(checkout), "rev-parse", "HEAD"],  # noqa: S607
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return "unknown"
+
+
+def split_weight(cap: int, steps: int) -> list[int]:
+    """Split a cap into positive, near-equal acquisition weights."""
+    count = min(cap, steps)
+    base, remainder = divmod(cap, count)
+    return [base + (1 if index < remainder else 0) for index in range(count)]
+
+
+def event_timestamps(now: int, interval: int, count: int) -> list[int]:
+    """Distribute events over one complete sliding window."""
+    start = now - interval + 1
+    if count == 1:
+        return [now]
+    return [start + ((interval - 1) * index // (count - 1)) for index in range(count)]
+
+
+def command_value(info: dict[str, Any], command: str, field: str) -> float:
+    """Read one numeric INFO commandstats field."""
+    return float(info.get(f"cmdstat_{command}", {}).get(field, 0))
+
+
+def server_snapshot(redis: Any) -> dict[str, float]:
+    """Capture server-wide counters used to calculate workload deltas."""
+    cpu = redis.info("cpu")
+    stats = redis.info("stats")
+    commands = redis.info("commandstats")
+    return {
+        "cpu_seconds": float(cpu.get("used_cpu_sys", 0)) + float(cpu.get("used_cpu_user", 0)),
+        "net_input_bytes": float(stats.get("total_net_input_bytes", 0)),
+        "net_output_bytes": float(stats.get("total_net_output_bytes", 0)),
+        "evalsha_calls": command_value(commands, "evalsha", "calls"),
+        "evalsha_usec": command_value(commands, "evalsha", "usec"),
+        "zrem_calls": command_value(commands, "zremrangebyscore", "calls"),
+        "zrem_usec": command_value(commands, "zremrangebyscore", "usec"),
+    }
+
+
+def subtract_snapshots(before: dict[str, float], after: dict[str, float]) -> dict[str, float]:
+    """Return non-negative server counter deltas."""
+    return {key: max(0.0, after[key] - value) for key, value in before.items()}
+
+
+def start_ping_sampler(redis_url: str, interval_ms: float) -> tuple[Event, Thread, list[int], list[str]]:
+    """Continuously sample PING latency from an independent connection."""
+    ready = Event()
+    stop = Event()
+    samples_ns: list[int] = []
+    errors: list[str] = []
+
+    def sample() -> None:
+        from redis import Redis
+
+        client = Redis.from_url(redis_url)
+        try:
+            client.ping()
+            ready.set()
+            while not stop.is_set():
+                started = perf_counter_ns()
+                client.ping()
+                samples_ns.append(perf_counter_ns() - started)
+                if interval_ms:
+                    sleep(interval_ms / 1_000)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(repr(exc))
+            ready.set()
+        finally:
+            client.close()
+
+    thread = Thread(target=sample, name="redis-pressure-ping", daemon=True)
+    thread.start()
+    if not ready.wait(timeout=5):
+        raise RuntimeError("PING sampler did not connect within five seconds")
+    if errors:
+        raise RuntimeError(f"PING sampler failed: {errors[0]}")
+    return stop, thread, samples_ns, errors
+
+
+def put_timed(bucket: Any, item: Any) -> int:
+    """Put one item and return elapsed nanoseconds."""
+    started = perf_counter_ns()
+    accepted = bucket.put(item)
+    elapsed = perf_counter_ns() - started
+    if not accepted:
+        raise RuntimeError("benchmark put was rejected")
+    return elapsed
+
+
+def fill_bucket(bucket: Any, item_type: Any, cap: int, interval: int, steps: int) -> tuple[list[int], list[int]]:
+    """Fill a bucket and return event timestamps and their weights."""
+    weights = split_weight(cap, steps)
+    timestamps = event_timestamps(bucket.now(), interval, len(weights))
+    for index, (timestamp, weight) in enumerate(zip(timestamps, weights, strict=False)):
+        accepted = bucket.put(item_type(f"prefill-{index}", timestamp, weight=weight))
+        if not accepted:
+            raise RuntimeError("benchmark prefill was rejected")
+    return timestamps, weights
+
+
+def growth_workload(
+    bucket: Any,
+    item_type: Any,
+    redis: Any,
+    key: str,
+    cap: int,
+    interval: int,
+    steps: int,
+) -> tuple[list[int], int, list[dict[str, int]]]:
+    """Fill an empty bucket and sample pressure at occupancy checkpoints."""
+    weights = split_weight(cap, steps)
+    timestamps = event_timestamps(bucket.now(), interval, len(weights))
+    thresholds = [25, 50, 75, 100]
+    checkpoints: list[dict[str, int]] = []
+    latencies_ns: list[int] = []
+    inserted = 0
+
+    for index, (timestamp, weight) in enumerate(zip(timestamps, weights, strict=False)):
+        item = item_type(f"growth-{index}", timestamp, weight=weight)
+        latencies_ns.append(put_timed(bucket, item))
+        inserted += weight
+        while thresholds and inserted * 100 >= cap * thresholds[0]:
+            checkpoints.append(
+                {
+                    "fill_pct": thresholds.pop(0),
+                    "cardinality": int(redis.zcard(key)),
+                    "memory_bytes": int(redis.memory_usage(key) or 0),
+                }
+            )
+
+    return latencies_ns, inserted, checkpoints
+
+
+def steady_workload(
+    bucket: Any,
+    item_type: Any,
+    redis: Any,
+    key: str,
+    timestamps: list[int],
+    weights: list[int],
+    interval: int,
+    cycles: int,
+) -> tuple[list[int], int, list[dict[str, int]]]:
+    """Replace expired acquisitions while keeping bucket occupancy stable."""
+    latencies_ns: list[int] = []
+    replaced = 0
+
+    for cycle in range(cycles):
+        for index, weight in enumerate(weights):
+            timestamps[index] += interval + 1
+            timestamp = timestamps[index]
+            started = perf_counter_ns()
+            bucket.leak(timestamp)
+            accepted = bucket.put(item_type(f"steady-{cycle}-{index}", timestamp, weight=weight))
+            latencies_ns.append(perf_counter_ns() - started)
+            if not accepted:
+                raise RuntimeError("steady-state replacement was rejected")
+            replaced += weight
+
+    checkpoints = [
+        {
+            "fill_pct": 100,
+            "cardinality": int(redis.zcard(key)),
+            "memory_bytes": int(redis.memory_usage(key) or 0),
+        }
+    ]
+    return latencies_ns, replaced, checkpoints
+
+
+def run_worker(args: argparse.Namespace) -> None:
+    """Run one isolated checkout/workload and emit raw measurements."""
+    sys.path.insert(0, str(args.checkout))
+
+    from redis import Redis
+
+    from pyrate_limiter import Rate, RateItem, RedisBucket
+
+    redis = Redis.from_url(args.redis_url)
+    redis.ping()
+    interval = WINDOWS_MS[args.window]
+    key = f"benchmark:redis-pressure:{args.label}:{args.workload}:{args.window}:{os.getpid()}"
+    bucket = RedisBucket.init([Rate(args.cap, interval)], redis, key)
+    redis.delete(key)
+
+    try:
+        steady_state: tuple[list[int], list[int]] | None = None
+        if args.workload == "steady":
+            steady_state = fill_bucket(bucket, RateItem, args.cap, interval, args.steps)
+
+        before = server_snapshot(redis)
+        stop, thread, ping_samples_ns, ping_errors = start_ping_sampler(args.redis_url, args.ping_interval_ms)
+        try:
+            started = perf_counter()
+            if args.workload == "growth":
+                operation_samples_ns, units, checkpoints = growth_workload(bucket, RateItem, redis, key, args.cap, interval, args.steps)
+            else:
+                assert steady_state is not None
+                operation_samples_ns, units, checkpoints = steady_workload(
+                    bucket,
+                    RateItem,
+                    redis,
+                    key,
+                    steady_state[0],
+                    steady_state[1],
+                    interval,
+                    args.steady_cycles,
+                )
+            elapsed_seconds = perf_counter() - started
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+
+        if thread.is_alive():
+            raise RuntimeError("PING sampler did not stop")
+        if ping_errors:
+            raise RuntimeError(f"PING sampler failed: {ping_errors[0]}")
+        after = server_snapshot(redis)
+        payload = {
+            "label": args.label,
+            "workload": args.workload,
+            "window": args.window,
+            "cap": args.cap,
+            "operation_samples_ns": operation_samples_ns,
+            "ping_samples_ns": ping_samples_ns,
+            "elapsed_seconds": elapsed_seconds,
+            "units": units,
+            "operations": len(operation_samples_ns),
+            "final_cardinality": int(redis.zcard(key)),
+            "final_memory_bytes": int(redis.memory_usage(key) or 0),
+            "checkpoints": checkpoints,
+            "telemetry": subtract_snapshots(before, after),
+        }
+    finally:
+        redis.delete(key)
+        redis.close()
+
+    print(json.dumps(payload))  # noqa: T201
+
+
+def run_block(
+    args: argparse.Namespace,
+    label: str,
+    checkout: Path,
+    workload: str,
+    window: str,
+    cap: int,
+) -> dict[str, Any]:
+    """Run one worker subprocess so checkout imports cannot mix."""
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--worker",
+        "--checkout",
+        str(checkout),
+        "--label",
+        label,
+        "--workload",
+        workload,
+        "--window",
+        window,
+        "--cap",
+        str(cap),
+        "--steps",
+        str(args.steps),
+        "--steady-cycles",
+        str(args.steady_cycles),
+        "--ping-interval-ms",
+        str(args.ping_interval_ms),
+        "--redis-url",
+        args.redis_url,
+    ]
+    completed = subprocess.run(  # noqa: S603
+        command, check=True, capture_output=True, text=True
+    )
+    return json.loads(completed.stdout)
+
+
+def median_checkpoint(runs: list[dict[str, Any]], fill_pct: int, field: str) -> float:
+    """Return the median checkpoint measurement across rounds."""
+    values = [checkpoint[field] for run in runs for checkpoint in run["checkpoints"] if checkpoint["fill_pct"] == fill_pct]
+    return float(statistics.median(values)) if values else 0.0
+
+
+def summarize_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate raw worker runs into client and Redis pressure metrics."""
+    operation_samples = [sample for run in runs for sample in run["operation_samples_ns"]]
+    ping_samples = [sample for run in runs for sample in run["ping_samples_ns"]]
+    telemetry = {key: sum(float(run["telemetry"][key]) for run in runs) for key in runs[0]["telemetry"]}
+    elapsed_seconds = sum(float(run["elapsed_seconds"]) for run in runs)
+    units = sum(int(run["units"]) for run in runs)
+    operations = sum(int(run["operations"]) for run in runs)
+    return {
+        "rounds": len(runs),
+        "operations": operations,
+        "units": units,
+        "elapsed_seconds": elapsed_seconds,
+        "units_per_second": units / elapsed_seconds,
+        "operation_p50_us": percentile_ns(operation_samples, 0.50),
+        "operation_p95_us": percentile_ns(operation_samples, 0.95),
+        "operation_p99_us": percentile_ns(operation_samples, 0.99),
+        "ping_samples": len(ping_samples),
+        "ping_p50_us": percentile_ns(ping_samples, 0.50),
+        "ping_p95_us": percentile_ns(ping_samples, 0.95),
+        "ping_p99_us": percentile_ns(ping_samples, 0.99),
+        "ping_max_us": max(ping_samples, default=0) / 1_000,
+        "final_cardinality": statistics.median(int(run["final_cardinality"]) for run in runs),
+        "final_memory_bytes": statistics.median(int(run["final_memory_bytes"]) for run in runs),
+        "memory_at_25_pct": median_checkpoint(runs, 25, "memory_bytes"),
+        "memory_at_50_pct": median_checkpoint(runs, 50, "memory_bytes"),
+        "memory_at_75_pct": median_checkpoint(runs, 75, "memory_bytes"),
+        "memory_at_100_pct": median_checkpoint(runs, 100, "memory_bytes"),
+        "telemetry": telemetry,
+    }
+
+
+def reduction_pct(baseline: float, candidate: float) -> float:
+    """Return positive percentages when the candidate uses less time or CPU."""
+    if baseline == 0:
+        return 0.0
+    return (1 - candidate / baseline) * 100
+
+
+def render_markdown(results: dict[str, Any]) -> str:
+    """Render compact pressure tables suitable for a pull request comment."""
+    lines = [
+        f"Baseline: {results['baseline_commit'][:12]}; candidate: "
+        f"{results['candidate_commit'][:12]}; Redis: {results['redis_version']}; "
+        f"rounds: {results['rounds']}.",
+        "",
+        "Server-wide CPU/network deltas require a dedicated Redis instance.",
+        "",
+    ]
+    for workload in results["workloads"]:
+        lines.extend(
+            [
+                f"### {workload.title()}",
+                "",
+                "| Window | Cap | Baseline op p95 | Candidate op p95 | Op reduction | PING samples B/C | Baseline PING p99/max | Candidate PING p99/max | CPU reduction | EVALSHA reduction | Memory | ZCARD |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for scenario in results["scenarios"]:
+            baseline = scenario[workload]["baseline"]
+            candidate = scenario[workload]["candidate"]
+            lines.append(
+                "| {window} | {cap:,} | {baseline_p95:.1f} us | {candidate_p95:.1f} us | "
+                "{op_reduction:+.1f}% | {baseline_ping_samples:,}/{candidate_ping_samples:,} | {baseline_ping_p99:.1f}/{baseline_ping_max:.1f} us | "
+                "{candidate_ping_p99:.1f}/{candidate_ping_max:.1f} us | {cpu_reduction:+.1f}% | "
+                "{evalsha_reduction:+.1f}% | {memory_kib:.1f} KiB | {cardinality:,.0f} |".format(
+                    window=scenario["window"].title(),
+                    cap=scenario["cap"],
+                    baseline_p95=baseline["operation_p95_us"],
+                    candidate_p95=candidate["operation_p95_us"],
+                    op_reduction=reduction_pct(baseline["operation_p95_us"], candidate["operation_p95_us"]),
+                    baseline_ping_samples=baseline["ping_samples"],
+                    candidate_ping_samples=candidate["ping_samples"],
+                    baseline_ping_p99=baseline["ping_p99_us"],
+                    baseline_ping_max=baseline["ping_max_us"],
+                    candidate_ping_p99=candidate["ping_p99_us"],
+                    candidate_ping_max=candidate["ping_max_us"],
+                    cpu_reduction=reduction_pct(
+                        baseline["telemetry"]["cpu_seconds"],
+                        candidate["telemetry"]["cpu_seconds"],
+                    ),
+                    evalsha_reduction=reduction_pct(
+                        baseline["telemetry"]["evalsha_usec"],
+                        candidate["telemetry"]["evalsha_usec"],
+                    ),
+                    memory_kib=candidate["final_memory_bytes"] / 1_024,
+                    cardinality=candidate["final_cardinality"],
+                )
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def compare(args: argparse.Namespace) -> None:
+    """Alternate checkouts across rounds and aggregate pressure measurements."""
+    from redis import Redis
+
+    checkouts = {
+        "baseline": args.baseline.resolve(),
+        "candidate": args.candidate.resolve(),
+    }
+    scenarios = args.scenario or DEFAULT_SCENARIOS
+    raw: dict[tuple[str, str, str], list[dict[str, Any]]] = {
+        (label, workload, window): [] for label in checkouts for workload in args.workloads for window, _ in scenarios
+    }
+
+    redis = Redis.from_url(args.redis_url)
+    redis_version = str(redis.info("server")["redis_version"])
+    redis.close()
+
+    for round_index in range(args.rounds):
+        order = ("baseline", "candidate") if round_index % 2 == 0 else ("candidate", "baseline")
+        for window, cap in scenarios:
+            for workload in args.workloads:
+                for label in order:
+                    raw[(label, workload, window)].append(
+                        run_block(
+                            args,
+                            label,
+                            checkouts[label],
+                            workload,
+                            window,
+                            cap,
+                        )
+                    )
+
+    scenario_results = []
+    for window, cap in scenarios:
+        workloads = {workload: {label: summarize_runs(raw[(label, workload, window)]) for label in checkouts} for workload in args.workloads}
+        scenario_results.append({"window": window, "cap": cap, **workloads})
+
+    results = {
+        "baseline_commit": checkout_commit(checkouts["baseline"]),
+        "candidate_commit": checkout_commit(checkouts["candidate"]),
+        "redis_version": redis_version,
+        "rounds": args.rounds,
+        "workloads": args.workloads,
+        "steps": args.steps,
+        "steady_cycles": args.steady_cycles,
+        "ping_interval_ms": args.ping_interval_ms,
+        "scenarios": scenario_results,
+    }
+    if args.json_output:
+        args.json_output.write_text(json.dumps(results, indent=2) + "\n")
+    print(render_markdown(results))  # noqa: T201
+
+
+def parse_scenario(value: str) -> tuple[str, int]:
+    """Parse WINDOW=CAP command-line values."""
+    try:
+        window, cap_text = value.split("=", 1)
+        cap = int(cap_text)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("scenario must use WINDOW=CAP") from exc
+    if window not in WINDOWS_MS:
+        raise argparse.ArgumentTypeError(f"unknown window {window!r}; choose from {', '.join(WINDOWS_MS)}")
+    if cap < 1:
+        raise argparse.ArgumentTypeError("scenario cap must be positive")
+    return window, cap
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--candidate", type=Path)
+    parser.add_argument("--redis-url", default=os.getenv("REDIS", "redis://localhost:6379"))
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        type=parse_scenario,
+        help="repeatable WINDOW=CAP; defaults to second=60 through month=100000",
+    )
+    parser.add_argument("--workloads", nargs="+", choices=WORKLOADS, default=list(WORKLOADS))
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=DEFAULT_ROUNDS,
+        help="repeat every checkout/workload/scenario (default: %(default)s)",
+    )
+    parser.add_argument("--steps", type=int, default=100)
+    parser.add_argument("--steady-cycles", type=int, default=2)
+    parser.add_argument("--ping-interval-ms", type=float, default=1.0)
+    parser.add_argument("--json-output", type=Path)
+
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--checkout", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--label", help=argparse.SUPPRESS)
+    parser.add_argument("--workload", choices=WORKLOADS, help=argparse.SUPPRESS)
+    parser.add_argument("--window", choices=WINDOWS_MS, help=argparse.SUPPRESS)
+    parser.add_argument("--cap", type=int, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    for option in ("rounds", "steps", "steady_cycles"):
+        if getattr(args, option) < 1:
+            parser.error(f"--{option.replace('_', '-')} must be at least 1")
+    if args.ping_interval_ms < 0:
+        parser.error("--ping-interval-ms cannot be negative")
+
+    if args.worker:
+        required = (
+            args.checkout,
+            args.label,
+            args.workload,
+            args.window,
+            args.cap,
+        )
+        if any(value is None for value in required):
+            parser.error("worker mode requires checkout, label, workload, window, and cap")
+    elif args.baseline is None or args.candidate is None:
+        parser.error("comparison mode requires baseline and candidate checkouts")
+    return args
+
+
+if __name__ == "__main__":
+    parsed = parse_args()
+    if parsed.worker:
+        run_worker(parsed)
+    else:
+        compare(parsed)

--- a/benchmarks/compare_redis_pressure.py
+++ b/benchmarks/compare_redis_pressure.py
@@ -1,14 +1,8 @@
 """Compare RedisBucket pressure between two source checkouts.
 
-Measures bucket growth and steady replacement while an independent connection
-samples PING latency. Use a dedicated Redis instance because CPU, network, and
+The benchmark fills and rotates realistic Redis buckets while a second client
+samples PING latency. Run it against a dedicated Redis instance because CPU and
 command statistics are server-wide.
-
-Example:
-    uv run --group all python benchmarks/compare_redis_pressure.py \
-        --baseline /tmp/pyrate-v4.3.0 \
-        --candidate /tmp/pyrate-v4.4.0 \
-        --redis-url redis://localhost:6379
 """
 
 from __future__ import annotations
@@ -17,15 +11,18 @@ import argparse
 import json
 import math
 import os
+import platform
 import statistics
 import subprocess
 import sys
 from pathlib import Path
 from threading import Event, Thread
-from time import perf_counter, perf_counter_ns, sleep
+from time import perf_counter_ns, sleep
 from typing import Any
 
 DEFAULT_ROUNDS = 5
+DEFAULT_STEPS = 100
+DEFAULT_STEADY_CYCLES = 2
 DEFAULT_SCENARIOS = [
     ("second", 60),
     ("minute", 1_000),
@@ -43,7 +40,7 @@ WINDOWS_MS = {
 WORKLOADS = ("growth", "steady")
 
 
-def percentile_ns(values: list[int], fraction: float) -> float:
+def percentile_us(values: list[int], fraction: float) -> float:
     """Return a nearest-rank percentile in microseconds."""
     if not values:
         return 0.0
@@ -54,62 +51,66 @@ def percentile_ns(values: list[int], fraction: float) -> float:
 
 def checkout_commit(checkout: Path) -> str:
     """Return the checkout commit when it is a Git worktree."""
-    try:
-        return subprocess.check_output(  # noqa: S603
-            ["git", "-C", str(checkout), "rev-parse", "HEAD"],  # noqa: S607
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-    except subprocess.CalledProcessError:
+    return subprocess.check_output(  # noqa: S603
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],  # noqa: S607
+        text=True,
+    ).strip()
+
+
+def read_first(path: Path, prefix: str) -> str:
+    """Read the first matching value from a Linux proc file."""
+    if not path.exists():
         return "unknown"
+    for line in path.read_text().splitlines():
+        if line.startswith(prefix):
+            return line.split(":", 1)[-1].strip()
+    return "unknown"
+
+
+def runner_resources() -> dict[str, Any]:
+    """Describe the machine so benchmark results are reproducible."""
+    return {
+        "os": platform.platform(),
+        "runner_image": os.getenv("ImageOS", "local"),
+        "runner_image_version": os.getenv("ImageVersion", "unknown"),
+        "python": platform.python_version(),
+        "cpu_model": read_first(Path("/proc/cpuinfo"), "model name"),
+        "cpu_count": os.cpu_count() or 0,
+        "memory_total": read_first(Path("/proc/meminfo"), "MemTotal"),
+    }
 
 
 def split_weight(cap: int, steps: int) -> list[int]:
     """Split a cap into positive, near-equal acquisition weights."""
     count = min(cap, steps)
     base, remainder = divmod(cap, count)
-    return [base + (1 if index < remainder else 0) for index in range(count)]
+    return [base + (index < remainder) for index in range(count)]
 
 
 def event_timestamps(now: int, interval: int, count: int) -> list[int]:
     """Distribute events over one complete sliding window."""
-    start = now - interval + 1
     if count == 1:
         return [now]
+    start = now - interval + 1
     return [start + ((interval - 1) * index // (count - 1)) for index in range(count)]
 
 
-def command_value(info: dict[str, Any], command: str, field: str) -> float:
-    """Read one numeric INFO commandstats field."""
-    return float(info.get(f"cmdstat_{command}", {}).get(field, 0))
-
-
 def server_snapshot(redis: Any) -> dict[str, float]:
-    """Capture server-wide counters used to calculate workload deltas."""
+    """Capture the two Redis counters used by the report."""
     cpu = redis.info("cpu")
-    stats = redis.info("stats")
     commands = redis.info("commandstats")
+    evalsha = commands.get("cmdstat_evalsha", {})
     return {
         "cpu_seconds": float(cpu.get("used_cpu_sys", 0)) + float(cpu.get("used_cpu_user", 0)),
-        "net_input_bytes": float(stats.get("total_net_input_bytes", 0)),
-        "net_output_bytes": float(stats.get("total_net_output_bytes", 0)),
-        "evalsha_calls": command_value(commands, "evalsha", "calls"),
-        "evalsha_usec": command_value(commands, "evalsha", "usec"),
-        "zrem_calls": command_value(commands, "zremrangebyscore", "calls"),
-        "zrem_usec": command_value(commands, "zremrangebyscore", "usec"),
+        "evalsha_usec": float(evalsha.get("usec", 0)),
     }
 
 
-def subtract_snapshots(before: dict[str, float], after: dict[str, float]) -> dict[str, float]:
-    """Return non-negative server counter deltas."""
-    return {key: max(0.0, after[key] - value) for key, value in before.items()}
-
-
 def start_ping_sampler(redis_url: str, interval_ms: float) -> tuple[Event, Thread, list[int], list[str]]:
-    """Continuously sample PING latency from an independent connection."""
+    """Sample unrelated Redis latency from an independent connection."""
     ready = Event()
     stop = Event()
-    samples_ns: list[int] = []
+    samples: list[int] = []
     errors: list[str] = []
 
     def sample() -> None:
@@ -122,116 +123,64 @@ def start_ping_sampler(redis_url: str, interval_ms: float) -> tuple[Event, Threa
             while not stop.is_set():
                 started = perf_counter_ns()
                 client.ping()
-                samples_ns.append(perf_counter_ns() - started)
-                if interval_ms:
-                    sleep(interval_ms / 1_000)
+                samples.append(perf_counter_ns() - started)
+                sleep(interval_ms / 1_000)
         except Exception as exc:  # noqa: BLE001
             errors.append(repr(exc))
             ready.set()
         finally:
             client.close()
 
-    thread = Thread(target=sample, name="redis-pressure-ping", daemon=True)
+    thread = Thread(target=sample, daemon=True)
     thread.start()
-    if not ready.wait(timeout=5):
-        raise RuntimeError("PING sampler did not connect within five seconds")
-    if errors:
-        raise RuntimeError(f"PING sampler failed: {errors[0]}")
-    return stop, thread, samples_ns, errors
-
-
-def put_timed(bucket: Any, item: Any) -> int:
-    """Put one item and return elapsed nanoseconds."""
-    started = perf_counter_ns()
-    accepted = bucket.put(item)
-    elapsed = perf_counter_ns() - started
-    if not accepted:
-        raise RuntimeError("benchmark put was rejected")
-    return elapsed
+    if not ready.wait(timeout=5) or errors:
+        raise RuntimeError(errors[0] if errors else "PING sampler did not start")
+    return stop, thread, samples, errors
 
 
 def fill_bucket(bucket: Any, item_type: Any, cap: int, interval: int, steps: int) -> tuple[list[int], list[int]]:
-    """Fill a bucket and return event timestamps and their weights."""
+    """Fill a bucket to its cap and return event timestamps and weights."""
     weights = split_weight(cap, steps)
     timestamps = event_timestamps(bucket.now(), interval, len(weights))
-    for index, (timestamp, weight) in enumerate(zip(timestamps, weights, strict=False)):
-        accepted = bucket.put(item_type(f"prefill-{index}", timestamp, weight=weight))
-        if not accepted:
-            raise RuntimeError("benchmark prefill was rejected")
+    for index, (timestamp, weight) in enumerate(zip(timestamps, weights, strict=True)):
+        if not bucket.put(item_type(f"fill-{index}", timestamp, weight=weight)):
+            raise RuntimeError("bucket prefill was rejected")
     return timestamps, weights
 
 
-def growth_workload(
+def run_workload(
+    args: argparse.Namespace,
     bucket: Any,
     item_type: Any,
-    redis: Any,
-    key: str,
-    cap: int,
-    interval: int,
-    steps: int,
-) -> tuple[list[int], int, list[dict[str, int]]]:
-    """Fill an empty bucket and sample pressure at occupancy checkpoints."""
-    weights = split_weight(cap, steps)
-    timestamps = event_timestamps(bucket.now(), interval, len(weights))
-    thresholds = [25, 50, 75, 100]
-    checkpoints: list[dict[str, int]] = []
-    latencies_ns: list[int] = []
-    inserted = 0
-
-    for index, (timestamp, weight) in enumerate(zip(timestamps, weights, strict=False)):
-        item = item_type(f"growth-{index}", timestamp, weight=weight)
-        latencies_ns.append(put_timed(bucket, item))
-        inserted += weight
-        while thresholds and inserted * 100 >= cap * thresholds[0]:
-            checkpoints.append(
-                {
-                    "fill_pct": thresholds.pop(0),
-                    "cardinality": int(redis.zcard(key)),
-                    "memory_bytes": int(redis.memory_usage(key) or 0),
-                }
-            )
-
-    return latencies_ns, inserted, checkpoints
-
-
-def steady_workload(
-    bucket: Any,
-    item_type: Any,
-    redis: Any,
-    key: str,
-    timestamps: list[int],
-    weights: list[int],
-    interval: int,
-    cycles: int,
-) -> tuple[list[int], int, list[dict[str, int]]]:
-    """Replace expired acquisitions while keeping bucket occupancy stable."""
-    latencies_ns: list[int] = []
-    replaced = 0
-
+    steady_state: tuple[list[int], list[int]] | None,
+) -> list[int]:
+    """Execute growth or steady replacement and return operation latency."""
+    interval = WINDOWS_MS[args.window]
+    if steady_state is None:
+        weights = split_weight(args.cap, args.steps)
+        timestamps = event_timestamps(bucket.now(), interval, len(weights))
+    else:
+        timestamps, weights = steady_state
+    samples: list[int] = []
+    cycles = args.steady_cycles if args.workload == "steady" else 1
     for cycle in range(cycles):
         for index, weight in enumerate(weights):
-            timestamps[index] += interval + 1
             timestamp = timestamps[index]
+            if args.workload == "steady":
+                timestamp += interval + 1
+                timestamps[index] = timestamp
             started = perf_counter_ns()
-            bucket.leak(timestamp)
-            accepted = bucket.put(item_type(f"steady-{cycle}-{index}", timestamp, weight=weight))
-            latencies_ns.append(perf_counter_ns() - started)
+            if args.workload == "steady":
+                bucket.leak(timestamp)
+            accepted = bucket.put(item_type(f"{args.workload}-{cycle}-{index}", timestamp, weight=weight))
+            samples.append(perf_counter_ns() - started)
             if not accepted:
-                raise RuntimeError("steady-state replacement was rejected")
-            replaced += weight
-
-    checkpoints = [
-        {
-            "fill_pct": 100,
-            "cardinality": int(redis.zcard(key)),
-            "memory_bytes": int(redis.memory_usage(key) or 0),
-        }
-    ]
-    return latencies_ns, replaced, checkpoints
+                raise RuntimeError("benchmark operation was rejected")
+    return samples
 
 
 def run_worker(args: argparse.Namespace) -> None:
-    """Run one isolated checkout/workload and emit raw measurements."""
+    """Measure one checkout and print raw samples as JSON."""
     sys.path.insert(0, str(args.checkout))
 
     from redis import Redis
@@ -239,59 +188,31 @@ def run_worker(args: argparse.Namespace) -> None:
     from pyrate_limiter import Rate, RateItem, RedisBucket
 
     redis = Redis.from_url(args.redis_url)
-    redis.ping()
-    interval = WINDOWS_MS[args.window]
     key = f"benchmark:redis-pressure:{args.label}:{args.workload}:{args.window}:{os.getpid()}"
-    bucket = RedisBucket.init([Rate(args.cap, interval)], redis, key)
+    bucket = RedisBucket.init([Rate(args.cap, WINDOWS_MS[args.window])], redis, key)
     redis.delete(key)
 
     try:
-        steady_state: tuple[list[int], list[int]] | None = None
+        steady_state = None
         if args.workload == "steady":
-            steady_state = fill_bucket(bucket, RateItem, args.cap, interval, args.steps)
-
+            steady_state = fill_bucket(bucket, RateItem, args.cap, WINDOWS_MS[args.window], args.steps)
         before = server_snapshot(redis)
-        stop, thread, ping_samples_ns, ping_errors = start_ping_sampler(args.redis_url, args.ping_interval_ms)
+        stop, thread, ping_samples, ping_errors = start_ping_sampler(args.redis_url, args.ping_interval_ms)
         try:
-            started = perf_counter()
-            if args.workload == "growth":
-                operation_samples_ns, units, checkpoints = growth_workload(bucket, RateItem, redis, key, args.cap, interval, args.steps)
-            else:
-                assert steady_state is not None
-                operation_samples_ns, units, checkpoints = steady_workload(
-                    bucket,
-                    RateItem,
-                    redis,
-                    key,
-                    steady_state[0],
-                    steady_state[1],
-                    interval,
-                    args.steady_cycles,
-                )
-            elapsed_seconds = perf_counter() - started
+            operation_samples = run_workload(args, bucket, RateItem, steady_state)
         finally:
             stop.set()
             thread.join(timeout=5)
-
-        if thread.is_alive():
-            raise RuntimeError("PING sampler did not stop")
-        if ping_errors:
-            raise RuntimeError(f"PING sampler failed: {ping_errors[0]}")
+        if thread.is_alive() or ping_errors:
+            raise RuntimeError(ping_errors[0] if ping_errors else "PING sampler did not stop")
         after = server_snapshot(redis)
         payload = {
-            "label": args.label,
-            "workload": args.workload,
-            "window": args.window,
-            "cap": args.cap,
-            "operation_samples_ns": operation_samples_ns,
-            "ping_samples_ns": ping_samples_ns,
-            "elapsed_seconds": elapsed_seconds,
-            "units": units,
-            "operations": len(operation_samples_ns),
-            "final_cardinality": int(redis.zcard(key)),
-            "final_memory_bytes": int(redis.memory_usage(key) or 0),
-            "checkpoints": checkpoints,
-            "telemetry": subtract_snapshots(before, after),
+            "operation_samples": operation_samples,
+            "ping_samples": ping_samples,
+            "memory_bytes": int(redis.memory_usage(key) or 0),
+            "cardinality": int(redis.zcard(key)),
+            "cpu_seconds": max(0.0, after["cpu_seconds"] - before["cpu_seconds"]),
+            "evalsha_usec": max(0.0, after["evalsha_usec"] - before["evalsha_usec"]),
         }
     finally:
         redis.delete(key)
@@ -300,7 +221,7 @@ def run_worker(args: argparse.Namespace) -> None:
     print(json.dumps(payload))  # noqa: T201
 
 
-def run_block(
+def run_worker_process(
     args: argparse.Namespace,
     label: str,
     checkout: Path,
@@ -308,7 +229,7 @@ def run_block(
     window: str,
     cap: int,
 ) -> dict[str, Any]:
-    """Run one worker subprocess so checkout imports cannot mix."""
+    """Run an isolated checkout so its imports cannot mix."""
     command = [
         sys.executable,
         str(Path(__file__).resolve()),
@@ -323,6 +244,8 @@ def run_block(
         window,
         "--cap",
         str(cap),
+        "--rounds",
+        "1",
         "--steps",
         str(args.steps),
         "--steady-cycles",
@@ -332,105 +255,84 @@ def run_block(
         "--redis-url",
         args.redis_url,
     ]
-    completed = subprocess.run(  # noqa: S603
-        command, check=True, capture_output=True, text=True
-    )
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)  # noqa: S603
     return json.loads(completed.stdout)
 
 
-def median_checkpoint(runs: list[dict[str, Any]], fill_pct: int, field: str) -> float:
-    """Return the median checkpoint measurement across rounds."""
-    values = [checkpoint[field] for run in runs for checkpoint in run["checkpoints"] if checkpoint["fill_pct"] == fill_pct]
-    return float(statistics.median(values)) if values else 0.0
-
-
-def summarize_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
-    """Aggregate raw worker runs into client and Redis pressure metrics."""
-    operation_samples = [sample for run in runs for sample in run["operation_samples_ns"]]
-    ping_samples = [sample for run in runs for sample in run["ping_samples_ns"]]
-    telemetry = {key: sum(float(run["telemetry"][key]) for run in runs) for key in runs[0]["telemetry"]}
-    elapsed_seconds = sum(float(run["elapsed_seconds"]) for run in runs)
-    units = sum(int(run["units"]) for run in runs)
-    operations = sum(int(run["operations"]) for run in runs)
+def summarize(runs: list[dict[str, Any]]) -> dict[str, float]:
+    """Aggregate repeated worker runs."""
+    operations = [value for run in runs for value in run["operation_samples"]]
+    pings = [value for run in runs for value in run["ping_samples"]]
     return {
-        "rounds": len(runs),
-        "operations": operations,
-        "units": units,
-        "elapsed_seconds": elapsed_seconds,
-        "units_per_second": units / elapsed_seconds,
-        "operation_p50_us": percentile_ns(operation_samples, 0.50),
-        "operation_p95_us": percentile_ns(operation_samples, 0.95),
-        "operation_p99_us": percentile_ns(operation_samples, 0.99),
-        "ping_samples": len(ping_samples),
-        "ping_p50_us": percentile_ns(ping_samples, 0.50),
-        "ping_p95_us": percentile_ns(ping_samples, 0.95),
-        "ping_p99_us": percentile_ns(ping_samples, 0.99),
-        "ping_max_us": max(ping_samples, default=0) / 1_000,
-        "final_cardinality": statistics.median(int(run["final_cardinality"]) for run in runs),
-        "final_memory_bytes": statistics.median(int(run["final_memory_bytes"]) for run in runs),
-        "memory_at_25_pct": median_checkpoint(runs, 25, "memory_bytes"),
-        "memory_at_50_pct": median_checkpoint(runs, 50, "memory_bytes"),
-        "memory_at_75_pct": median_checkpoint(runs, 75, "memory_bytes"),
-        "memory_at_100_pct": median_checkpoint(runs, 100, "memory_bytes"),
-        "telemetry": telemetry,
+        "operation_p95_us": percentile_us(operations, 0.95),
+        "ping_p99_us": percentile_us(pings, 0.99),
+        "ping_max_us": max(pings, default=0) / 1_000,
+        "ping_samples": len(pings),
+        "memory_bytes": statistics.median(run["memory_bytes"] for run in runs),
+        "cardinality": statistics.median(run["cardinality"] for run in runs),
+        "cpu_seconds": sum(run["cpu_seconds"] for run in runs),
+        "evalsha_usec": sum(run["evalsha_usec"] for run in runs),
     }
 
 
-def reduction_pct(baseline: float, candidate: float) -> float:
-    """Return positive percentages when the candidate uses less time or CPU."""
-    if baseline == 0:
-        return 0.0
-    return (1 - candidate / baseline) * 100
+def reduction(baseline: float, candidate: float) -> float:
+    """Return positive percentages when the candidate uses less."""
+    return 0.0 if baseline == 0 else (1 - candidate / baseline) * 100
 
 
 def render_markdown(results: dict[str, Any]) -> str:
-    """Render compact pressure tables suitable for a pull request comment."""
+    """Render runner resources and pressure results."""
+    resources = results["resources"]
     lines = [
-        f"Baseline: {results['baseline_commit'][:12]}; candidate: "
-        f"{results['candidate_commit'][:12]}; Redis: {results['redis_version']}; "
-        f"rounds: {results['rounds']}.",
+        "## Redis pressure benchmark",
         "",
-        "Server-wide CPU/network deltas require a dedicated Redis instance.",
+        f"Baseline {results['baseline_commit'][:12]}; candidate {results['candidate_commit'][:12]}; Redis {results['redis_version']}.",
+        "",
+        "### Environment",
+        "",
+        "| Resource | Value |",
+        "| --- | --- |",
+        f"| Runner | {resources['runner_image']} {resources['runner_image_version']} |",
+        f"| OS | {resources['os']} |",
+        f"| CPU | {resources['cpu_model']} ({resources['cpu_count']} logical CPUs) |",
+        f"| RAM | {resources['memory_total']} |",
+        f"| Python | {resources['python']} |",
+        f"| Redis maxmemory | {results['redis_maxmemory']} bytes ({results['redis_policy']}) |",
+        f"| Configuration | {results['rounds']} rounds, {results['steps']} steps, {results['steady_cycles']} steady cycles |",
         "",
     ]
-    for workload in results["workloads"]:
+    for workload in WORKLOADS:
         lines.extend(
             [
                 f"### {workload.title()}",
                 "",
-                "| Window | Cap | Baseline op p95 | Candidate op p95 | Op reduction | PING samples B/C | Baseline PING p99/max | Candidate PING p99/max | CPU reduction | EVALSHA reduction | Memory | ZCARD |",
-                "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+                "| Window | Cap | Op p95 B/C | Reduction | PING samples B/C | PING p99 B/C | PING max B/C | CPU reduction | EVALSHA reduction | Memory | ZCARD |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
             ]
         )
         for scenario in results["scenarios"]:
             baseline = scenario[workload]["baseline"]
             candidate = scenario[workload]["candidate"]
             lines.append(
-                "| {window} | {cap:,} | {baseline_p95:.1f} us | {candidate_p95:.1f} us | "
-                "{op_reduction:+.1f}% | {baseline_ping_samples:,}/{candidate_ping_samples:,} | {baseline_ping_p99:.1f}/{baseline_ping_max:.1f} us | "
-                "{candidate_ping_p99:.1f}/{candidate_ping_max:.1f} us | {cpu_reduction:+.1f}% | "
-                "{evalsha_reduction:+.1f}% | {memory_kib:.1f} KiB | {cardinality:,.0f} |".format(
+                "| {window} | {cap:,} | {op_b:.1f}/{op_c:.1f} us | {op_r:+.1f}% | "
+                "{ping_n_b:.0f}/{ping_n_c:.0f} | {ping_b:.1f}/{ping_c:.1f} us | "
+                "{ping_max_b:.1f}/{ping_max_c:.1f} us | {cpu_r:+.1f}% | {eval_r:+.1f}% | "
+                "{memory:.1f} KiB | {cardinality:,.0f} |".format(
                     window=scenario["window"].title(),
                     cap=scenario["cap"],
-                    baseline_p95=baseline["operation_p95_us"],
-                    candidate_p95=candidate["operation_p95_us"],
-                    op_reduction=reduction_pct(baseline["operation_p95_us"], candidate["operation_p95_us"]),
-                    baseline_ping_samples=baseline["ping_samples"],
-                    candidate_ping_samples=candidate["ping_samples"],
-                    baseline_ping_p99=baseline["ping_p99_us"],
-                    baseline_ping_max=baseline["ping_max_us"],
-                    candidate_ping_p99=candidate["ping_p99_us"],
-                    candidate_ping_max=candidate["ping_max_us"],
-                    cpu_reduction=reduction_pct(
-                        baseline["telemetry"]["cpu_seconds"],
-                        candidate["telemetry"]["cpu_seconds"],
-                    ),
-                    evalsha_reduction=reduction_pct(
-                        baseline["telemetry"]["evalsha_usec"],
-                        candidate["telemetry"]["evalsha_usec"],
-                    ),
-                    memory_kib=candidate["final_memory_bytes"] / 1_024,
-                    cardinality=candidate["final_cardinality"],
+                    op_b=baseline["operation_p95_us"],
+                    op_c=candidate["operation_p95_us"],
+                    op_r=reduction(baseline["operation_p95_us"], candidate["operation_p95_us"]),
+                    ping_n_b=baseline["ping_samples"],
+                    ping_n_c=candidate["ping_samples"],
+                    ping_b=baseline["ping_p99_us"],
+                    ping_c=candidate["ping_p99_us"],
+                    ping_max_b=baseline["ping_max_us"],
+                    ping_max_c=candidate["ping_max_us"],
+                    cpu_r=reduction(baseline["cpu_seconds"], candidate["cpu_seconds"]),
+                    eval_r=reduction(baseline["evalsha_usec"], candidate["evalsha_usec"]),
+                    memory=candidate["memory_bytes"] / 1_024,
+                    cardinality=candidate["cardinality"],
                 )
             )
         lines.append("")
@@ -438,57 +340,51 @@ def render_markdown(results: dict[str, Any]) -> str:
 
 
 def compare(args: argparse.Namespace) -> None:
-    """Alternate checkouts across rounds and aggregate pressure measurements."""
+    """Compare both checkouts across all configured scenarios."""
     from redis import Redis
 
-    checkouts = {
-        "baseline": args.baseline.resolve(),
-        "candidate": args.candidate.resolve(),
-    }
+    checkouts = {"baseline": args.baseline.resolve(), "candidate": args.candidate.resolve()}
     scenarios = args.scenario or DEFAULT_SCENARIOS
     raw: dict[tuple[str, str, str], list[dict[str, Any]]] = {
-        (label, workload, window): [] for label in checkouts for workload in args.workloads for window, _ in scenarios
+        (label, workload, window): [] for label in checkouts for workload in WORKLOADS for window, _ in scenarios
     }
-
-    redis = Redis.from_url(args.redis_url)
-    redis_version = str(redis.info("server")["redis_version"])
-    redis.close()
-
     for round_index in range(args.rounds):
         order = ("baseline", "candidate") if round_index % 2 == 0 else ("candidate", "baseline")
         for window, cap in scenarios:
-            for workload in args.workloads:
+            for workload in WORKLOADS:
                 for label in order:
-                    raw[(label, workload, window)].append(
-                        run_block(
-                            args,
-                            label,
-                            checkouts[label],
-                            workload,
-                            window,
-                            cap,
-                        )
-                    )
+                    raw[(label, workload, window)].append(run_worker_process(args, label, checkouts[label], workload, window, cap))
 
-    scenario_results = []
-    for window, cap in scenarios:
-        workloads = {workload: {label: summarize_runs(raw[(label, workload, window)]) for label in checkouts} for workload in args.workloads}
-        scenario_results.append({"window": window, "cap": cap, **workloads})
-
+    redis = Redis.from_url(args.redis_url)
+    server = redis.info("server")
+    memory = redis.info("memory")
+    policy = redis.config_get("maxmemory-policy")
+    redis.close()
     results = {
         "baseline_commit": checkout_commit(checkouts["baseline"]),
         "candidate_commit": checkout_commit(checkouts["candidate"]),
-        "redis_version": redis_version,
+        "redis_version": server["redis_version"],
+        "redis_maxmemory": memory.get("maxmemory", 0),
+        "redis_policy": policy.get("maxmemory-policy", "unknown"),
+        "resources": runner_resources(),
         "rounds": args.rounds,
-        "workloads": args.workloads,
         "steps": args.steps,
         "steady_cycles": args.steady_cycles,
-        "ping_interval_ms": args.ping_interval_ms,
-        "scenarios": scenario_results,
+        "scenarios": [
+            {
+                "window": window,
+                "cap": cap,
+                **{workload: {label: summarize(raw[(label, workload, window)]) for label in checkouts} for workload in WORKLOADS},
+            }
+            for window, cap in scenarios
+        ],
     }
+    markdown = render_markdown(results)
     if args.json_output:
         args.json_output.write_text(json.dumps(results, indent=2) + "\n")
-    print(render_markdown(results))  # noqa: T201
+    if args.markdown_output:
+        args.markdown_output.write_text(markdown + "\n")
+    print(markdown)  # noqa: T201
 
 
 def parse_scenario(value: str) -> tuple[str, int]:
@@ -498,10 +394,8 @@ def parse_scenario(value: str) -> tuple[str, int]:
         cap = int(cap_text)
     except ValueError as exc:
         raise argparse.ArgumentTypeError("scenario must use WINDOW=CAP") from exc
-    if window not in WINDOWS_MS:
-        raise argparse.ArgumentTypeError(f"unknown window {window!r}; choose from {', '.join(WINDOWS_MS)}")
-    if cap < 1:
-        raise argparse.ArgumentTypeError("scenario cap must be positive")
+    if window not in WINDOWS_MS or cap < 1:
+        raise argparse.ArgumentTypeError("scenario must use a known WINDOW and positive CAP")
     return window, cap
 
 
@@ -510,24 +404,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--baseline", type=Path)
     parser.add_argument("--candidate", type=Path)
     parser.add_argument("--redis-url", default=os.getenv("REDIS", "redis://localhost:6379"))
-    parser.add_argument(
-        "--scenario",
-        action="append",
-        type=parse_scenario,
-        help="repeatable WINDOW=CAP; defaults to second=60 through month=100000",
-    )
-    parser.add_argument("--workloads", nargs="+", choices=WORKLOADS, default=list(WORKLOADS))
-    parser.add_argument(
-        "--rounds",
-        type=int,
-        default=DEFAULT_ROUNDS,
-        help="repeat every checkout/workload/scenario (default: %(default)s)",
-    )
-    parser.add_argument("--steps", type=int, default=100)
-    parser.add_argument("--steady-cycles", type=int, default=2)
+    parser.add_argument("--scenario", action="append", type=parse_scenario)
+    parser.add_argument("--rounds", type=int, default=DEFAULT_ROUNDS)
+    parser.add_argument("--steps", type=int, default=DEFAULT_STEPS)
+    parser.add_argument("--steady-cycles", type=int, default=DEFAULT_STEADY_CYCLES)
     parser.add_argument("--ping-interval-ms", type=float, default=1.0)
     parser.add_argument("--json-output", type=Path)
-
+    parser.add_argument("--markdown-output", type=Path)
     parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--checkout", type=Path, help=argparse.SUPPRESS)
     parser.add_argument("--label", help=argparse.SUPPRESS)
@@ -536,21 +419,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cap", type=int, help=argparse.SUPPRESS)
     args = parser.parse_args()
 
-    for option in ("rounds", "steps", "steady_cycles"):
-        if getattr(args, option) < 1:
-            parser.error(f"--{option.replace('_', '-')} must be at least 1")
-    if args.ping_interval_ms < 0:
-        parser.error("--ping-interval-ms cannot be negative")
-
+    if args.rounds < 1 or args.steps < 1 or args.steady_cycles < 1 or args.ping_interval_ms < 0:
+        parser.error("rounds, steps, and cycles must be positive; ping interval cannot be negative")
     if args.worker:
-        required = (
-            args.checkout,
-            args.label,
-            args.workload,
-            args.window,
-            args.cap,
-        )
-        if any(value is None for value in required):
+        if any(value is None for value in (args.checkout, args.label, args.workload, args.window, args.cap)):
             parser.error("worker mode requires checkout, label, workload, window, and cap")
     elif args.baseline is None or args.candidate is None:
         parser.error("comparison mode requires baseline and candidate checkouts")
@@ -559,7 +431,4 @@ def parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     parsed = parse_args()
-    if parsed.worker:
-        run_worker(parsed)
-    else:
-        compare(parsed)
+    run_worker(parsed) if parsed.worker else compare(parsed)

--- a/benchmarks/compare_redis_pressure.py
+++ b/benchmarks/compare_redis_pressure.py
@@ -69,14 +69,19 @@ def read_first(path: Path, prefix: str) -> str:
 
 def runner_resources() -> dict[str, Any]:
     """Describe the machine so benchmark results are reproducible."""
+    affinity = os.sched_getaffinity(0) if hasattr(os, "sched_getaffinity") else set()
     return {
         "os": platform.platform(),
         "runner_image": os.getenv("ImageOS", "local"),
         "runner_image_version": os.getenv("ImageVersion", "unknown"),
         "python": platform.python_version(),
         "cpu_model": read_first(Path("/proc/cpuinfo"), "model name"),
-        "cpu_count": os.cpu_count() or 0,
+        "host_cpu_count": os.cpu_count() or 0,
+        "benchmark_cpu_count": len(affinity) if affinity else os.cpu_count() or 0,
+        "benchmark_cpu_set": ",".join(str(cpu) for cpu in sorted(affinity)) or "unknown",
         "memory_total": read_first(Path("/proc/meminfo"), "MemTotal"),
+        "redis_cpu_limit": os.getenv("REDIS_CPU_LIMIT", "unlimited"),
+        "redis_memory_limit": os.getenv("REDIS_MEMORY_LIMIT", "unlimited"),
     }
 
 
@@ -294,8 +299,10 @@ def render_markdown(results: dict[str, Any]) -> str:
         "| --- | --- |",
         f"| Runner | {resources['runner_image']} {resources['runner_image_version']} |",
         f"| OS | {resources['os']} |",
-        f"| CPU | {resources['cpu_model']} ({resources['cpu_count']} logical CPUs) |",
-        f"| RAM | {resources['memory_total']} |",
+        f"| Host CPU | {resources['cpu_model']} ({resources['host_cpu_count']} logical CPUs) |",
+        f"| Benchmark CPU | {resources['benchmark_cpu_count']} logical CPU; affinity {resources['benchmark_cpu_set']} |",
+        f"| Redis container | {resources['redis_cpu_limit']} CPU; {resources['redis_memory_limit']} memory |",
+        f"| Host RAM | {resources['memory_total']} |",
         f"| Python | {resources['python']} |",
         f"| Redis maxmemory | {results['redis_maxmemory']} bytes ({results['redis_policy']}) |",
         f"| Configuration | {results['rounds']} rounds, {results['steps']} steps, {results['steady_cycles']} steady cycles |",

--- a/benchmarks/compare_redis_weighted_put.py
+++ b/benchmarks/compare_redis_weighted_put.py
@@ -1,0 +1,219 @@
+"""Compare weighted RedisBucket put latency between two source checkouts.
+
+Example:
+    uv run --group all python benchmarks/compare_redis_weighted_put.py \
+        --baseline /tmp/pyrate-master \
+        --candidate /tmp/pyrate-candidate \
+        --redis-url redis://localhost:6379
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+from time import perf_counter_ns
+from typing import Any
+
+DEFAULT_WEIGHTS = [1, 10, 100, 1000, 5000]
+
+
+def percentile(values: list[int], fraction: float) -> float:
+    """Return a nearest-rank percentile in microseconds."""
+    ordered = sorted(values)
+    index = max(0, math.ceil(len(ordered) * fraction) - 1)
+    return ordered[index] / 1_000
+
+
+def checkout_commit(checkout: Path) -> str:
+    """Return the checkout commit when it is a Git worktree."""
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return "unknown"
+
+
+def iterations_for_weight(args: argparse.Namespace, weight: int) -> int:
+    """Keep each round useful without making large weights prohibitively slow."""
+    estimated = args.target_members_per_round // weight
+    return max(args.min_iterations, min(args.max_iterations, estimated))
+
+
+def run_worker(args: argparse.Namespace) -> None:
+    """Measure one checkout and print raw nanosecond samples as JSON."""
+    sys.path.insert(0, str(args.checkout))
+
+    from redis import Redis
+
+    from pyrate_limiter import Rate, RateItem, RedisBucket
+
+    redis = Redis.from_url(args.redis_url)
+    redis.ping()
+    key = f"benchmark:redis-weight:{args.label}:{args.weight}:{os.getpid()}"
+    bucket = RedisBucket.init([Rate(args.weight, 60_000)], redis, key)
+    samples_ns: list[int] = []
+
+    try:
+        for index in range(args.warmup + args.iterations):
+            redis.delete(key)
+            item = RateItem("benchmark", bucket.now(), weight=args.weight)
+            started = perf_counter_ns()
+            accepted = bucket.put(item)
+            elapsed = perf_counter_ns() - started
+            if not accepted:
+                raise RuntimeError("benchmark put was rejected")
+            if index >= args.warmup:
+                samples_ns.append(elapsed)
+    finally:
+        redis.delete(key)
+        redis.close()
+
+    print(json.dumps({"label": args.label, "weight": args.weight, "samples_ns": samples_ns}))
+
+
+def run_block(
+    args: argparse.Namespace,
+    label: str,
+    checkout: Path,
+    weight: int,
+    iterations: int,
+) -> list[int]:
+    """Run an isolated worker so imports from the two checkouts cannot mix."""
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--worker",
+        "--checkout",
+        str(checkout),
+        "--label",
+        label,
+        "--weight",
+        str(weight),
+        "--iterations",
+        str(iterations),
+        "--warmup",
+        str(args.warmup),
+        "--redis-url",
+        args.redis_url,
+    ]
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    return json.loads(completed.stdout)["samples_ns"]
+
+
+def render_markdown(results: dict[str, Any]) -> str:
+    """Render a compact table suitable for a pull request comment."""
+    lines = [
+        f"Baseline: `{results['baseline_commit'][:12]}`; candidate: `{results['candidate_commit'][:12]}`; "
+        f"Redis: `{results['redis_version']}`; rounds: {results['rounds']}.",
+        "",
+        "| Weight | Samples/version | Baseline median | Candidate median | Median reduction | Baseline p95 | Candidate p95 |",
+        "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in results["rows"]:
+        lines.append(
+            "| {weight} | {samples_per_version} | {baseline_median_us:.1f} us | "
+            "{candidate_median_us:.1f} us | {median_reduction_pct:+.1f}% | "
+            "{baseline_p95_us:.1f} us | {candidate_p95_us:.1f} us |".format(**row)
+        )
+    return "\n".join(lines)
+
+
+def compare(args: argparse.Namespace) -> None:
+    """Alternate both checkouts across rounds and summarize their samples."""
+    from redis import Redis
+
+    checkouts = {
+        "baseline": args.baseline.resolve(),
+        "candidate": args.candidate.resolve(),
+    }
+    samples: dict[tuple[str, int], list[int]] = {
+        (label, weight): [] for label in checkouts for weight in args.weights
+    }
+
+    redis = Redis.from_url(args.redis_url)
+    redis_version = str(redis.info("server")["redis_version"])
+    redis.close()
+
+    for round_index in range(args.rounds):
+        order = ("baseline", "candidate") if round_index % 2 == 0 else ("candidate", "baseline")
+        for weight in args.weights:
+            iterations = iterations_for_weight(args, weight)
+            for label in order:
+                samples[(label, weight)].extend(
+                    run_block(args, label, checkouts[label], weight, iterations)
+                )
+
+    rows = []
+    for weight in args.weights:
+        baseline = samples[("baseline", weight)]
+        candidate = samples[("candidate", weight)]
+        baseline_median = statistics.median(baseline) / 1_000
+        candidate_median = statistics.median(candidate) / 1_000
+        rows.append(
+            {
+                "weight": weight,
+                "samples_per_version": len(baseline),
+                "baseline_median_us": baseline_median,
+                "candidate_median_us": candidate_median,
+                "median_reduction_pct": (1 - candidate_median / baseline_median) * 100,
+                "baseline_p95_us": percentile(baseline, 0.95),
+                "candidate_p95_us": percentile(candidate, 0.95),
+            }
+        )
+
+    results = {
+        "baseline_commit": checkout_commit(checkouts["baseline"]),
+        "candidate_commit": checkout_commit(checkouts["candidate"]),
+        "redis_version": redis_version,
+        "rounds": args.rounds,
+        "rows": rows,
+    }
+    if args.json_output:
+        args.json_output.write_text(json.dumps(results, indent=2) + "\n")
+    print(render_markdown(results))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--candidate", type=Path)
+    parser.add_argument("--redis-url", default=os.getenv("REDIS", "redis://localhost:6379"))
+    parser.add_argument("--weights", nargs="+", type=int, default=DEFAULT_WEIGHTS)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--target-members-per-round", type=int, default=120_000)
+    parser.add_argument("--min-iterations", type=int, default=40)
+    parser.add_argument("--max-iterations", type=int, default=1000)
+    parser.add_argument("--json-output", type=Path)
+
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--checkout", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--label", help=argparse.SUPPRESS)
+    parser.add_argument("--weight", type=int, help=argparse.SUPPRESS)
+    parser.add_argument("--iterations", type=int, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if args.worker:
+        required = (args.checkout, args.label, args.weight, args.iterations)
+        if any(value is None for value in required):
+            parser.error("worker mode requires checkout, label, weight, and iterations")
+    elif args.baseline is None or args.candidate is None:
+        parser.error("comparison mode requires baseline and candidate checkouts")
+    return args
+
+
+if __name__ == "__main__":
+    parsed = parse_args()
+    if parsed.worker:
+        run_worker(parsed)
+    else:
+        compare(parsed)

--- a/benchmarks/compare_redis_weighted_put.py
+++ b/benchmarks/compare_redis_weighted_put.py
@@ -4,7 +4,12 @@ Example:
     uv run --group all python benchmarks/compare_redis_weighted_put.py \
         --baseline /tmp/pyrate-master \
         --candidate /tmp/pyrate-candidate \
-        --redis-url redis://localhost:6379
+        --redis-url redis://localhost:6379 \
+        --windows second minute hour day month
+
+The key is reset before every sample, so this benchmark isolates weighted put
+latency. Window duration is reported independently from retained-set occupancy,
+which should be benchmarked separately for long-lived production buckets.
 """
 
 from __future__ import annotations
@@ -21,6 +26,14 @@ from time import perf_counter_ns
 from typing import Any
 
 DEFAULT_WEIGHTS = [1, 10, 100, 1000, 5000]
+DEFAULT_ROUNDS = 5
+WINDOWS_MS = {
+    "second": 1_000,
+    "minute": 60_000,
+    "hour": 3_600_000,
+    "day": 86_400_000,
+    "month": 2_592_000_000,
+}
 
 
 def percentile(values: list[int], fraction: float) -> float:
@@ -33,8 +46,8 @@ def percentile(values: list[int], fraction: float) -> float:
 def checkout_commit(checkout: Path) -> str:
     """Return the checkout commit when it is a Git worktree."""
     try:
-        return subprocess.check_output(
-            ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        return subprocess.check_output(  # noqa: S603
+            ["git", "-C", str(checkout), "rev-parse", "HEAD"],  # noqa: S607
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()
@@ -58,8 +71,8 @@ def run_worker(args: argparse.Namespace) -> None:
 
     redis = Redis.from_url(args.redis_url)
     redis.ping()
-    key = f"benchmark:redis-weight:{args.label}:{args.weight}:{os.getpid()}"
-    bucket = RedisBucket.init([Rate(args.weight, 60_000)], redis, key)
+    key = f"benchmark:redis-weight:{args.label}:{args.window}:{args.weight}:{os.getpid()}"
+    bucket = RedisBucket.init([Rate(args.weight, args.window_ms)], redis, key)
     samples_ns: list[int] = []
 
     try:
@@ -77,13 +90,23 @@ def run_worker(args: argparse.Namespace) -> None:
         redis.delete(key)
         redis.close()
 
-    print(json.dumps({"label": args.label, "weight": args.weight, "samples_ns": samples_ns}))
+    print(  # noqa: T201
+        json.dumps(
+            {
+                "label": args.label,
+                "window": args.window,
+                "weight": args.weight,
+                "samples_ns": samples_ns,
+            }
+        )
+    )
 
 
 def run_block(
     args: argparse.Namespace,
     label: str,
     checkout: Path,
+    window: str,
     weight: int,
     iterations: int,
 ) -> list[int]:
@@ -96,6 +119,10 @@ def run_block(
         str(checkout),
         "--label",
         label,
+        "--window",
+        window,
+        "--window-ms",
+        str(WINDOWS_MS[window]),
         "--weight",
         str(weight),
         "--iterations",
@@ -105,7 +132,9 @@ def run_block(
         "--redis-url",
         args.redis_url,
     ]
-    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    completed = subprocess.run(  # noqa: S603
+        command, check=True, capture_output=True, text=True
+    )
     return json.loads(completed.stdout)["samples_ns"]
 
 
@@ -115,15 +144,23 @@ def render_markdown(results: dict[str, Any]) -> str:
         f"Baseline: `{results['baseline_commit'][:12]}`; candidate: `{results['candidate_commit'][:12]}`; "
         f"Redis: `{results['redis_version']}`; rounds: {results['rounds']}.",
         "",
-        "| Weight | Samples/version | Baseline median | Candidate median | Median reduction | Baseline p95 | Candidate p95 |",
-        "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
-    for row in results["rows"]:
-        lines.append(
-            "| {weight} | {samples_per_version} | {baseline_median_us:.1f} us | "
-            "{candidate_median_us:.1f} us | {median_reduction_pct:+.1f}% | "
-            "{baseline_p95_us:.1f} us | {candidate_p95_us:.1f} us |".format(**row)
+    for window in results["windows"]:
+        lines.extend(
+            [
+                f"### {window['name'].title()} window ({window['duration_ms']:,} ms)",
+                "",
+                "| Weight | Samples/version | Baseline median | Candidate median | Median reduction | Baseline p95 | Candidate p95 |",
+                "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+            ]
         )
+        for row in window["rows"]:
+            lines.append(
+                "| {weight} | {samples_per_version} | {baseline_median_us:.1f} us | "
+                "{candidate_median_us:.1f} us | {median_reduction_pct:+.1f}% | "
+                "{baseline_p95_us:.1f} us | {candidate_p95_us:.1f} us |".format(**row)
+            )
+        lines.append("")
     return "\n".join(lines)
 
 
@@ -135,8 +172,8 @@ def compare(args: argparse.Namespace) -> None:
         "baseline": args.baseline.resolve(),
         "candidate": args.candidate.resolve(),
     }
-    samples: dict[tuple[str, int], list[int]] = {
-        (label, weight): [] for label in checkouts for weight in args.weights
+    samples: dict[tuple[str, str, int], list[int]] = {
+        (label, window, weight): [] for label in checkouts for window in args.windows for weight in args.weights
     }
 
     redis = Redis.from_url(args.redis_url)
@@ -145,28 +182,36 @@ def compare(args: argparse.Namespace) -> None:
 
     for round_index in range(args.rounds):
         order = ("baseline", "candidate") if round_index % 2 == 0 else ("candidate", "baseline")
-        for weight in args.weights:
-            iterations = iterations_for_weight(args, weight)
-            for label in order:
-                samples[(label, weight)].extend(
-                    run_block(args, label, checkouts[label], weight, iterations)
-                )
+        for window in args.windows:
+            for weight in args.weights:
+                iterations = iterations_for_weight(args, weight)
+                for label in order:
+                    samples[(label, window, weight)].extend(run_block(args, label, checkouts[label], window, weight, iterations))
 
-    rows = []
-    for weight in args.weights:
-        baseline = samples[("baseline", weight)]
-        candidate = samples[("candidate", weight)]
-        baseline_median = statistics.median(baseline) / 1_000
-        candidate_median = statistics.median(candidate) / 1_000
-        rows.append(
+    windows = []
+    for window in args.windows:
+        rows = []
+        for weight in args.weights:
+            baseline = samples[("baseline", window, weight)]
+            candidate = samples[("candidate", window, weight)]
+            baseline_median = statistics.median(baseline) / 1_000
+            candidate_median = statistics.median(candidate) / 1_000
+            rows.append(
+                {
+                    "weight": weight,
+                    "samples_per_version": len(baseline),
+                    "baseline_median_us": baseline_median,
+                    "candidate_median_us": candidate_median,
+                    "median_reduction_pct": (1 - candidate_median / baseline_median) * 100,
+                    "baseline_p95_us": percentile(baseline, 0.95),
+                    "candidate_p95_us": percentile(candidate, 0.95),
+                }
+            )
+        windows.append(
             {
-                "weight": weight,
-                "samples_per_version": len(baseline),
-                "baseline_median_us": baseline_median,
-                "candidate_median_us": candidate_median,
-                "median_reduction_pct": (1 - candidate_median / baseline_median) * 100,
-                "baseline_p95_us": percentile(baseline, 0.95),
-                "candidate_p95_us": percentile(candidate, 0.95),
+                "name": window,
+                "duration_ms": WINDOWS_MS[window],
+                "rows": rows,
             }
         )
 
@@ -175,11 +220,11 @@ def compare(args: argparse.Namespace) -> None:
         "candidate_commit": checkout_commit(checkouts["candidate"]),
         "redis_version": redis_version,
         "rounds": args.rounds,
-        "rows": rows,
+        "windows": windows,
     }
     if args.json_output:
         args.json_output.write_text(json.dumps(results, indent=2) + "\n")
-    print(render_markdown(results))
+    print(render_markdown(results))  # noqa: T201
 
 
 def parse_args() -> argparse.Namespace:
@@ -188,7 +233,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--candidate", type=Path)
     parser.add_argument("--redis-url", default=os.getenv("REDIS", "redis://localhost:6379"))
     parser.add_argument("--weights", nargs="+", type=int, default=DEFAULT_WEIGHTS)
-    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument(
+        "--windows",
+        nargs="+",
+        choices=WINDOWS_MS,
+        default=list(WINDOWS_MS),
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=DEFAULT_ROUNDS,
+        help="repeat every window/weight comparison (default: %(default)s)",
+    )
     parser.add_argument("--warmup", type=int, default=20)
     parser.add_argument("--target-members-per-round", type=int, default=120_000)
     parser.add_argument("--min-iterations", type=int, default=40)
@@ -198,14 +254,39 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--checkout", type=Path, help=argparse.SUPPRESS)
     parser.add_argument("--label", help=argparse.SUPPRESS)
+    parser.add_argument("--window", choices=WINDOWS_MS, help=argparse.SUPPRESS)
+    parser.add_argument("--window-ms", type=int, help=argparse.SUPPRESS)
     parser.add_argument("--weight", type=int, help=argparse.SUPPRESS)
     parser.add_argument("--iterations", type=int, help=argparse.SUPPRESS)
     args = parser.parse_args()
 
+    positive_options = {
+        "rounds": args.rounds,
+        "target-members-per-round": args.target_members_per_round,
+        "min-iterations": args.min_iterations,
+        "max-iterations": args.max_iterations,
+    }
+    for option, value in positive_options.items():
+        if value < 1:
+            parser.error(f"--{option} must be at least 1")
+    if args.warmup < 0:
+        parser.error("--warmup cannot be negative")
+    if args.min_iterations > args.max_iterations:
+        parser.error("--min-iterations cannot exceed --max-iterations")
+    if any(weight < 1 for weight in args.weights):
+        parser.error("--weights must contain positive integers")
+
     if args.worker:
-        required = (args.checkout, args.label, args.weight, args.iterations)
+        required = (
+            args.checkout,
+            args.label,
+            args.window,
+            args.window_ms,
+            args.weight,
+            args.iterations,
+        )
         if any(value is None for value in required):
-            parser.error("worker mode requires checkout, label, weight, and iterations")
+            parser.error("worker mode requires checkout, label, window, window-ms, weight, and iterations")
     elif args.baseline is None or args.candidate is None:
         parser.error("comparison mode requires baseline and candidate checkouts")
     return args


### PR DESCRIPTION
## Summary
- add a reusable benchmark for comparing weighted `RedisBucket.put()` latency across two source checkouts
- cover second, minute, hour, day, and 30-day month rate windows
- repeat every window/weight comparison for five rounds by default, alternating baseline/candidate order
- report median and p95 latency as Markdown, with optional JSON output
- keep retained-set occupancy explicit: this benchmark resets the key per sample and isolates weighted put cost

## Usage
```bash
uv run --group all python benchmarks/compare_redis_weighted_put.py \
  --baseline /tmp/pyrate-master \
  --candidate /tmp/pyrate-candidate \
  --redis-url redis://localhost:6379 \
  --windows second minute hour day month \
  --json-output /tmp/results.json
```

The script defaults to five rounds. Override with `--rounds`; each output row includes the accumulated sample count per version.

## Validation
- configured pre-commit checks: Ruff check, Ruff format, and mypy
- repeated smoke matrix against Redis 7.0.15 across all five windows
- full default comparison remains intended before this draft is marked ready