### PR TITLE
refactor: introduce Algorithm/Decision seam for sliding-window-log (R2)

### DIFF
--- a/pyrate_limiter/abstracts/algorithm.py
+++ b/pyrate_limiter/abstracts/algorithm.py
@@ -1,0 +1,77 @@
+"""Rate-limiting algorithm abstraction.
+
+Separates the *policy* (which rates admit an item, and how far back items can be
+leaked) from the *storage* that counts and persists those items. In v4 this is
+an internal seam: the built-in buckets delegate their per-rate admit decision
+and leak bound here, so the sliding-window-log logic lives in exactly one place
+instead of being copy-pasted across backends. v5 promotes ``Algorithm`` /
+``Decision`` to a public extension point (a ``Store`` interface plus a generic
+``Algorithm.check`` over it, with backends providing optional native
+implementations), at which point ``Decision`` also carries retry-after and
+replaces the ``failing_rate`` instance-state side-channel + the bool return.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+from .rate import Rate
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Outcome of an admit check.
+
+    ``failing_rate is None`` means the item was admitted; otherwise it is the
+    first rate whose window was full. In v4 the retry-after is still derived
+    separately by ``AbstractBucket.waiting()``; v5 folds it into this type so a
+    single atomic check yields both the verdict and the wait.
+    """
+
+    failing_rate: Optional[Rate] = None
+
+    @property
+    def allowed(self) -> bool:
+        return self.failing_rate is None
+
+
+class Algorithm(ABC):
+    """A rate-limiting policy, expressed independently of any storage backend.
+
+    A bucket supplies the per-rate windowed counts (however it obtains them -
+    in-memory bisect, ``ZCOUNT``, ``COUNT(*) FILTER``...) and the algorithm
+    decides admission. Implementations must be stateless so a single instance
+    can be shared across buckets and threads.
+    """
+
+    @abstractmethod
+    def admit(self, rates: List[Rate], counts: Sequence[int], weight: int) -> Decision:
+        """Decide whether ``weight`` more items fit, given ``counts[i]`` items
+        already inside ``rates[i]``'s window (``counts`` aligned to ``rates``)."""
+
+    @abstractmethod
+    def leak_bound(self, rates: List[Rate], now: int) -> int:
+        """Timestamp below which an item is outside *every* rate's window and so
+        may be leaked."""
+
+
+class SlidingWindowLog(Algorithm):
+    """Precise sliding-window-log policy.
+
+    Admit while, for every rate, the count of items within its rolling interval
+    stays under the limit. This is PyrateLimiter's default and (until v5) only
+    algorithm; backends may implement it natively for atomicity/performance
+    (Redis Lua, Postgres lock + ``COUNT FILTER``, in-memory bisect) but share
+    this definition of the decision.
+    """
+
+    def admit(self, rates: List[Rate], counts: Sequence[int], weight: int) -> Decision:
+        for rate, count in zip(rates, counts, strict=True):
+            if rate.limit - int(count) < weight:
+                return Decision(failing_rate=rate)
+        return Decision()
+
+    def leak_bound(self, rates: List[Rate], now: int) -> int:
+        # rates are sorted ascending by interval (AbstractBucket.rates), so
+        # rates[-1] is the widest window.
+        return now - rates[-1].interval

--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -12,6 +12,7 @@ from typing import Any, Awaitable, Dict, List, Optional, Type, Union
 
 from ..clocks import AbstractClock, MonotonicClock
 from ..utils import enforce_rate_list
+from .algorithm import Algorithm, SlidingWindowLog
 from .rate import Rate, RateItem
 
 logger = logging.getLogger("pyrate_limiter")
@@ -26,6 +27,11 @@ class AbstractBucket(ABC):
     _rates: List[Rate]
     failing_rate: Optional[Rate] = None
     _clock: AbstractClock = MonotonicClock()
+    # The rate-limiting policy this bucket enforces. Internal in v4 (every
+    # bucket uses the sliding-window-log default and delegates its per-rate
+    # admit decision + leak bound to it); v5 makes this a constructor argument
+    # so algorithms (GCRA, sliding-window-counter) become pluggable.
+    _algorithm: Algorithm = SlidingWindowLog()
     # Whether this bucket's operations return awaitables. ``None`` means
     # "unknown" - the Leaker then probes once by calling ``leak(0)`` and
     # checking for a coroutine. Built-in sync/async buckets declare this so no

--- a/pyrate_limiter/buckets/in_memory_bucket.py
+++ b/pyrate_limiter/buckets/in_memory_bucket.py
@@ -42,6 +42,11 @@ class InMemoryBucket(AbstractBucket):
             return True
 
         with self._lock:
+            # In-memory native implementation of the SlidingWindowLog policy
+            # (see self._algorithm): the admit decision is the same
+            # `limit - count < weight` check, kept inline here so the
+            # `after_length < limit` shortcut can skip the bisect entirely
+            # rather than materialising a full per-rate counts list.
             current_length = len(self.items)
             after_length = item.weight + current_length
 
@@ -73,8 +78,7 @@ class InMemoryBucket(AbstractBucket):
         assert current_timestamp is not None
         with self._lock:
             if self.items:
-                max_interval = self.rates[-1].interval
-                lower_bound = current_timestamp - max_interval
+                lower_bound = self._algorithm.leak_bound(self.rates, current_timestamp)
 
                 if lower_bound > self.items[-1].timestamp:
                     remove_count = len(self.items)

--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -152,10 +152,10 @@ class PostgresBucket(AbstractBucket):
             counts = cur.fetchone()
             cur.close()
 
-            for rate, count in zip(self.rates, counts, strict=True):
-                if rate.limit - int(count) < item.weight:
-                    self.failing_rate = rate
-                    return False
+            decision = self._algorithm.admit(self.rates, counts, item.weight)
+            if not decision.allowed:
+                self.failing_rate = decision.failing_rate
+                return False
 
             self.failing_rate = None
             # Insert all `weight` unit-rows in a single statement (one round
@@ -170,7 +170,7 @@ class PostgresBucket(AbstractBucket):
     ) -> Union[int, Awaitable[int]]:
         """leaking bucket - removing items that are outdated"""
         assert current_timestamp is not None, "current-time must be passed on for leak"
-        lower_bound = current_timestamp - self.rates[-1].interval
+        lower_bound = self._algorithm.leak_bound(self.rates, current_timestamp)
 
         if lower_bound <= 0:
             return 0

--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -141,7 +141,7 @@ class RedisBucket(AbstractBucket):
         return self.redis.zremrangebyscore(
             self.bucket_key,
             0,
-            current_timestamp - self.rates[-1].interval,
+            self._algorithm.leak_bound(self.rates, current_timestamp),
         )
 
     def flush(self):

--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -37,7 +37,7 @@ class Queries:
     DELETE FROM "{table}" WHERE rowid IN (
     SELECT rowid FROM "{table}" ORDER BY item_timestamp ASC LIMIT {count});
     """.strip()
-    COUNT_BEFORE_LEAK = """SELECT COUNT(*) FROM '{table}' WHERE item_timestamp < {current_timestamp} - {interval}"""
+    COUNT_BEFORE_LEAK = """SELECT COUNT(*) FROM '{table}' WHERE item_timestamp < {lower_bound}"""
     FLUSH = """DELETE FROM '{table}'"""
     # The below sqls are for testing only
     DROP_TABLE = "DROP TABLE IF EXISTS '{table}'"
@@ -113,15 +113,18 @@ class SQLiteBucket(AbstractBucket):
             rate_limit_counts = cur.fetchall()
             cur.close()
 
-            for idx, result in enumerate(rate_limit_counts):
-                interval, count = result
-                rate = self.rates[idx]
+            # Each row is (interval, count); the UNION-of-COUNTs query returns
+            # them in ascending-interval order, matching self.rates. Verify that
+            # alignment, then defer the admit decision to the algorithm.
+            counts = []
+            for (interval, count), rate in zip(rate_limit_counts, self.rates, strict=True):
                 assert interval == rate.interval
-                space_available = rate.limit - count
+                counts.append(count)
 
-                if space_available < item.weight:
-                    self.failing_rate = rate
-                    return False
+            decision = self._algorithm.admit(self.rates, counts, item.weight)
+            if not decision.allowed:
+                self.failing_rate = decision.failing_rate
+                return False
 
             # Bind name + timestamp as parameters; never interpolate the
             # user-supplied name into SQL (injection / quote-crash).
@@ -142,8 +145,7 @@ class SQLiteBucket(AbstractBucket):
             assert current_timestamp is not None
             query = Queries.COUNT_BEFORE_LEAK.format(
                 table=self.table,
-                interval=self.rates[-1].interval,
-                current_timestamp=current_timestamp,
+                lower_bound=self._algorithm.leak_bound(self.rates, current_timestamp),
             )
             cur = self.conn.execute(query)
             count = cur.fetchone()[0]

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -1,0 +1,51 @@
+"""Unit tests for the Algorithm seam (R2): SlidingWindowLog + Decision."""
+from pyrate_limiter import InMemoryBucket, Rate
+from pyrate_limiter.abstracts.algorithm import Algorithm, Decision, SlidingWindowLog
+
+RATES = [Rate(3, 1000), Rate(5, 5000)]
+
+
+def test_decision_allowed_flag():
+    assert Decision().allowed is True
+    assert Decision().failing_rate is None
+    denied = Decision(failing_rate=RATES[0])
+    assert denied.allowed is False
+    assert denied.failing_rate is RATES[0]
+
+
+def test_sliding_window_log_is_algorithm():
+    assert isinstance(SlidingWindowLog(), Algorithm)
+
+
+def test_admit_allows_when_all_rates_fit():
+    algo = SlidingWindowLog()
+    # counts well under both limits
+    assert algo.admit(RATES, [0, 0], weight=1).allowed
+    assert algo.admit(RATES, [2, 4], weight=1).allowed  # exactly fills, still fits
+
+
+def test_admit_returns_first_violated_rate():
+    algo = SlidingWindowLog()
+    # first rate full (limit 3, count 3) -> can't fit 1 more
+    d = algo.admit(RATES, [3, 0], weight=1)
+    assert not d.allowed and d.failing_rate is RATES[0]
+    # first rate fits, second full
+    d = algo.admit(RATES, [0, 5], weight=1)
+    assert not d.allowed and d.failing_rate is RATES[1]
+
+
+def test_admit_respects_weight():
+    algo = SlidingWindowLog()
+    # limit 3, count 2 -> weight 1 fits, weight 2 does not
+    assert algo.admit(RATES, [2, 0], weight=1).allowed
+    assert not algo.admit(RATES, [2, 0], weight=2).allowed
+
+
+def test_leak_bound_is_widest_window():
+    algo = SlidingWindowLog()
+    # rates sorted ascending by interval -> widest is 5000
+    assert algo.leak_bound(RATES, now=10_000) == 10_000 - 5000
+
+
+def test_buckets_default_to_sliding_window_log():
+    assert isinstance(InMemoryBucket(RATES)._algorithm, SlidingWindowLog)


### PR DESCRIPTION
## Summary

Replaces the sliding-window-log logic that was copy-pasted across the four backends with an internal **algorithm abstraction** the buckets delegate to. This is the load-bearing seam the v5 pluggable-algorithm architecture is *promoted* from — not a one-off de-dup.

**No public API change.** `Algorithm` / `Decision` / `SlidingWindowLog` are intentionally not in the public `__all__` yet (internal seam); v5 exposes them and wires `Limiter(algorithm=…)`.

## What changed

- **`pyrate_limiter/abstracts/algorithm.py`** (new):
  - `Decision` — admit result (`failing_rate is None` ⇒ allowed). The keystone result type; v5 folds retry-after into it, replacing the `failing_rate` instance-state side-channel + the extra `peek` round-trip.
  - `Algorithm` (ABC) — `admit(rates, counts, weight) -> Decision` and `leak_bound(rates, now)`.
  - `SlidingWindowLog` — the default (and, until v5, only) policy.
- **`AbstractBucket._algorithm`** — class attribute paralleling `_clock`, defaulting to `SlidingWindowLog`. v5 turns this into a constructor argument.
- **Backends delegate the policy:** `SQLiteBucket.put` / `PostgresBucket.put` call `self._algorithm.admit(...) -> Decision`; all four backends' `leak()` use `self._algorithm.leak_bound(...)`. `InMemoryBucket.put` keeps its bisect early-break as the in-memory **native** implementation of the same policy.

## Why this shape

It separates *policy* (which rates admit) from *storage* (how counts are obtained: bisect / `ZCOUNT` / `COUNT(*) FILTER`). v5 promotes it to a public `Store` + `Algorithm` pair with a generic check path and optional native per-backend implementations, then adds GCRA / sliding-window-counter as additive algorithms — a promotion, not a rewrite.

## Testing

- Full non-external suite **156 passed, 1 skipped**, incl. new `tests/test_algorithm.py` (admit fit/violation/weight, `leak_bound`, bucket default).
- `ruff`, `ruff format`, `mypy` (package + tests) clean; import / circular-import check passes.
- ⚠️ Postgres `put` (`admit`) and Redis/Postgres `leak` (`leak_bound`) run only in the `postgres`/`redis` CI jobs — those are mechanical substitutions of the existing inline expressions.

## Relation to open PRs

No conflict with #306 (benchmarks only) or #284 (batches the Redis `PUT_ITEM` Lua — a disjoint region from this PR's one-line `leak()` change; rebases cleanly either order).

https://claude.ai/code/session_01WDgwnj6c9HQoogmHi1QaQw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDgwnj6c9HQoogmHi1QaQw)_