### PR TITLE
release: v4.4.0 changelog + auto-create GitHub Release with artifacts

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Download dist
@@ -160,3 +160,11 @@ jobs:
           path: dist
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Create GitHub Release with build artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.4.0]
+
+Bug-fix, scalability, and internal-refactor release. No public API changes
+(the new `AbstractBucket.is_async` attribute is additive).
+
+### Fixed
+- **InMemoryBucket**: guard the internal item list with a lock so the
+  background `Leaker` thread can no longer race `put`/`peek`/`leak`. This was a
+  data race in the default configuration (in-memory bucket + scheduled leak).
+  `MultiprocessBucket` aliases this lock to its shared cross-process lock. (#302)
+- **PostgresClock**: when the DB time query fails, fall back to local
+  **wall-clock** epoch time instead of monotonic time. The monotonic fallback
+  was ~5 orders of magnitude smaller than the stored epoch-ms timestamps and
+  would corrupt every window comparison and leak bound. (#302)
+- **Leaker**: make the background sync-leak worker restartable. Re-registering a
+  bucket after every bucket had been disposed previously raised
+  `RuntimeError: threads can only be started once`. (#302)
+- Keep `Limiter` picklable after the `InMemoryBucket` lock addition. (#302)
+
+### Performance & Scalability
+- **Limiter**: release the limiter lock during the synchronous blocking wait, so
+  a long wait on one key no longer serializes acquisitions for every other key
+  sharing the limiter. (#304)
+- **RedisBucket**: batch weighted `ZADD`s in bounded chunks inside the atomic
+  Lua script, lowering latency for high-weight puts. (#284)
+
+### Internal / Refactor
+- Unify the limiter's sync/async acquire plumbing into a single coroutine and
+  share the delay-step decision across the sync and async branches. (#303)
+- Add a declarative `is_async` bucket attribute so the `Leaker` no longer detects
+  async by executing a side-effecting `leak(0)` probe. `RedisBucket` still probes
+  because it may wrap either a sync or an async client. (#305)
+- Introduce an internal `Algorithm`/`Decision` seam (`SlidingWindowLog`) that the
+  built-in buckets delegate their per-rate admit decision and leak bound to —
+  the foundation for pluggable algorithms (e.g. GCRA, sliding-window-counter) in
+  a future release. (#307)
+
+### Documentation
+- Document that `RedisBucket` keeps one sorted-set member per consumed unit, and
+  that long-window / high-volume quotas may want a coarser counter-based backend
+  for bounded memory. (#284)
+
 ## [4.3.1]
 
 Performance and maintenance release. No API or behavior changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Bug-fix, scalability, and internal-refactor release. No public API changes
   that long-window / high-volume quotas may want a coarser counter-based backend
   for bounded memory. (#284)
 
+### CI
+- The release workflow now also creates a GitHub Release for the pushed tag and
+  attaches the built `dist/*` artifacts, in addition to publishing to PyPI.
+
 ## [4.3.1]
 
 Performance and maintenance release. No API or behavior changes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,25 +54,16 @@ Pushing a `v*` tag triggers the [build_test.yml](.github/workflows/build_test.ym
 1. **smoke** — lints and runs smoke tests
 2. **check-linux** — runs full test suite on Python 3.10, 3.14, 3.14t with Redis and Postgres services; builds the wheel on the latest Python
 3. **check-others** — runs tests on macOS and PyPy
-4. **publish** — downloads the built artifacts and publishes to PyPI via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+4. **publish** — downloads the built artifacts, publishes to PyPI via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), **and** creates a GitHub Release for the tag with auto-generated notes and the build artifacts attached.
 
-### 5. Create a GitHub Release
+### 5. (Optional) Verify / edit the GitHub Release
 
-After CI completes, create a GitHub Release and attach the build artifacts:
-
-```shell
-# Create release with auto-generated notes
-gh release create v<VERSION> --title "v<VERSION>" --generate-notes
-
-# Download CI-built artifacts and attach them
-gh run download <RUN_ID> --name dist --dir /tmp/pyrate-dist
-gh release upload v<VERSION> /tmp/pyrate-dist/*
-```
-
-To find the `<RUN_ID>`:
+CI creates the GitHub Release and attaches the `dist/*` artifacts automatically.
+Edit the auto-generated notes if you want a curated summary:
 
 ```shell
-gh run list --limit 5
+gh release view v<VERSION>
+gh release edit v<VERSION> --notes-file <path>   # optional
 ```
 
 ### 6. Update CHANGELOG.md


### PR DESCRIPTION
Release prep for **v4.4.0** (the "update docs first" step plus the artifact-to-GitHub-Release automation).

### Docs
- `CHANGELOG.md` entry for v4.4.0 (which also feeds `docs/changelog.md` via `{include}`), covering everything merged since v4.3.1: #302, #303, #304, #305, #284, #307. No public API/behavior changes (new `AbstractBucket.is_async` is additive) → minor bump.
- `RELEASING.md` updated to reflect that the GitHub Release is now created automatically.

### CI — automate the GitHub Release + artifact upload
The `publish` job previously only pushed to PyPI; the GitHub Release + `dist` attach was a manual `gh` step. It now also:
```
gh release create "$GITHUB_REF_NAME" dist/* --title "$GITHUB_REF_NAME" --generate-notes
```
using the runner's `gh` + `github.token` (job permission bumped to `contents: write`). So pushing a `v*` tag now publishes to PyPI **and** creates a GitHub Release with the build artifacts in one shot.

After this merges, pushing `v4.4.0` completes the release end-to-end.

https://claude.ai/code/session_01WDgwnj6c9HQoogmHi1QaQw