### PR TITLE
feat: fold retry-after into Decision (algorithms phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+Groundwork for pluggable algorithms. Additive — no breaking public API changes.
+
+### Added
+- `Decision` now carries `retry_after_ms` alongside the verdict, and `put()`
+  records it. `AbstractBucket.waiting()` reads that recording instead of
+  deriving the wait from storage a second time. Custom buckets that record
+  nothing keep working: `waiting()` falls back to the previous `peek()`-based
+  derivation.
+- `AbstractBucket.put_decision()` returns the full `Decision` for a put, so the
+  verdict and the retry-after arrive together rather than via the
+  `failing_rate` attribute plus a follow-up `waiting()` call.
+- `Algorithm`, `LogAlgorithm`, `Decision` and `SlidingWindowLog` are exported
+  from the package root.
+
+### Fixed
+- **SQLiteBucket**: a successful `put()` now clears `failing_rate`. Every other
+  backend already did; SQLite left the last denial standing indefinitely.
+
+### Performance
+- **RedisBucket**: the Lua script returns the blocking item's timestamp with the
+  verdict, so a rate-limited request no longer needs a second `ZRANGE` round
+  trip to learn how long to wait — and the wait can no longer be computed
+  against a sorted set that moved in between.
+- **PostgresBucket**: the retry-after is resolved inside the same `EXCLUSIVE`
+  table lock as the check, removing both a round trip and that same race.
+- **SQLiteBucket**: likewise resolved inside `put()`'s existing lock hold, so
+  the background `Leaker` cannot delete rows between the verdict and the wait.
+- **InMemoryBucket** / **MultiprocessBucket**: the wait falls out of the bisect
+  `put()` already performs — no second scan, and no allocation on the admit path.
+
+### Internal / Refactor
+- Split `LogAlgorithm` out of `Algorithm` for policies whose state is a log of
+  timestamped items. `leak_bound()` and the new `blocking_offset()` /
+  `retry_after()` hooks live there; constant-state policies (token bucket, GCRA)
+  will not implement it.
+- The inclusive-window `+1` boundary correction now lives in exactly one place
+  (`SlidingWindowLog.retry_after`) instead of being inlined in `waiting()`.
+
 ## [4.4.0]
 
 Bug-fix, scalability, and internal-refactor release. No public API changes

--- a/pyrate_limiter/__init__.py
+++ b/pyrate_limiter/__init__.py
@@ -1,11 +1,15 @@
 # flake8: noqa
 from ._version import __version__ as __version__
 from .abstracts import AbstractBucket as AbstractBucket
+from .abstracts import Algorithm as Algorithm
 from .abstracts import BucketAsyncWrapper as BucketAsyncWrapper
 from .abstracts import BucketFactory as BucketFactory
+from .abstracts import Decision as Decision
 from .abstracts import Duration as Duration
+from .abstracts import LogAlgorithm as LogAlgorithm
 from .abstracts import Rate as Rate
 from .abstracts import RateItem as RateItem
+from .abstracts import SlidingWindowLog as SlidingWindowLog
 from .buckets import InMemoryBucket as InMemoryBucket
 from .buckets import MultiprocessBucket as MultiprocessBucket
 from .buckets import PgQueries as PgQueries
@@ -28,11 +32,15 @@ from . import limiter_factory as limiter_factory
 __all__ = [
     "__version__",
     "AbstractBucket",
+    "Algorithm",
     "BucketAsyncWrapper",
     "BucketFactory",
+    "Decision",
     "Duration",
+    "LogAlgorithm",
     "Rate",
     "RateItem",
+    "SlidingWindowLog",
     "InMemoryBucket",
     "MultiprocessBucket",
     "PgQueries",

--- a/pyrate_limiter/abstracts/__init__.py
+++ b/pyrate_limiter/abstracts/__init__.py
@@ -1,3 +1,7 @@
+from .algorithm import Algorithm as Algorithm
+from .algorithm import Decision as Decision
+from .algorithm import LogAlgorithm as LogAlgorithm
+from .algorithm import SlidingWindowLog as SlidingWindowLog
 from .bucket import AbstractBucket as AbstractBucket
 from .bucket import BucketFactory as BucketFactory
 from .rate import Duration as Duration
@@ -6,6 +10,10 @@ from .rate import RateItem as RateItem
 from .wrappers import BucketAsyncWrapper as BucketAsyncWrapper
 
 __all__ = [
+    "Algorithm",
+    "Decision",
+    "LogAlgorithm",
+    "SlidingWindowLog",
     "AbstractBucket",
     "BucketFactory",
     "Duration",

--- a/pyrate_limiter/abstracts/algorithm.py
+++ b/pyrate_limiter/abstracts/algorithm.py
@@ -1,19 +1,29 @@
 """Rate-limiting algorithm abstraction.
 
-Separates the *policy* (which rates admit an item, and how far back items can be
-leaked) from the *storage* that counts and persists those items. In v4 this is
-an internal seam: the built-in buckets delegate their per-rate admit decision
-and leak bound here, so the sliding-window-log logic lives in exactly one place
-instead of being copy-pasted across backends. v5 promotes ``Algorithm`` /
-``Decision`` to a public extension point (a ``Store`` interface plus a generic
-``Algorithm.check`` over it, with backends providing optional native
-implementations), at which point ``Decision`` also carries retry-after and
-replaces the ``failing_rate`` instance-state side-channel + the bool return.
+Separates the *policy* (which rates admit an item, how long a rejected item must
+wait, and how far back items can be leaked) from the *storage* that counts and
+persists those items. In v4 this is an internal seam: the built-in buckets
+delegate their per-rate admit decision, retry-after and leak bound here, so the
+sliding-window-log logic lives in exactly one place instead of being
+copy-pasted across backends.
+
+``Decision`` carries the retry-after alongside the verdict, so a single check
+under a single lock yields both. This matters beyond tidiness: deriving the wait
+afterwards (the pre-4.5 ``AbstractBucket.waiting()`` path) costs a second
+round trip to the backend and reads state that may have changed since the put.
+It is also the prerequisite for algorithms whose state is *not* a log - a token
+bucket or GCRA has no k-th-newest item to look up, and computes its wait in
+closed form.
+
+``LogAlgorithm`` is the sub-interface for policies that do keep a log of
+timestamped items (everything shipped in v4). v5 adds a sibling for
+constant-state policies plus a ``Store`` interface they can share, at which
+point ``Algorithm`` becomes a public extension point.
 """
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional, Sequence
+from typing import Callable, Final, List, Optional, Sequence
 
 from .rate import Rate
 
@@ -23,16 +33,28 @@ class Decision:
     """Outcome of an admit check.
 
     ``failing_rate is None`` means the item was admitted; otherwise it is the
-    first rate whose window was full. In v4 the retry-after is still derived
-    separately by ``AbstractBucket.waiting()``; v5 folds it into this type so a
-    single atomic check yields both the verdict and the wait.
+    first rate whose window was full.
+
+    ``retry_after_ms`` is how long after the checked item's own timestamp the
+    same weight would fit, or ``None`` when the algorithm could not determine it
+    - either because the weight can never fit (it exceeds ``failing_rate.limit``)
+    or because the backend does not compute it. ``None`` is not "no wait": it
+    means "ask ``AbstractBucket.waiting()``", which falls back to deriving the
+    wait from storage.
     """
 
     failing_rate: Optional[Rate] = None
+    retry_after_ms: Optional[int] = None
 
     @property
     def allowed(self) -> bool:
         return self.failing_rate is None
+
+
+#: The verdict for an admitted item. ``Decision`` is immutable, so the same
+#: instance is reused on every successful put rather than allocating a fresh one
+#: on the hot path.
+ADMITTED: Final["Decision"] = Decision()
 
 
 class Algorithm(ABC):
@@ -47,15 +69,79 @@ class Algorithm(ABC):
     @abstractmethod
     def admit(self, rates: List[Rate], counts: Sequence[int], weight: int) -> Decision:
         """Decide whether ``weight`` more items fit, given ``counts[i]`` items
-        already inside ``rates[i]``'s window (``counts`` aligned to ``rates``)."""
+        already inside ``rates[i]``'s window (``counts`` aligned to ``rates``).
+
+        The returned ``Decision`` carries no retry-after; use ``decide()`` to
+        get both in one step.
+        """
+
+
+class LogAlgorithm(Algorithm):
+    """Policy over storage that keeps one timestamped entry per consumed unit.
+
+    Such a policy can answer "when does this become admissible?" by naming the
+    stored entry that has to fall out of the window first - so the retry-after
+    is a lookup plus arithmetic rather than a closed form. Constant-state
+    policies (token bucket, GCRA) will *not* implement this interface.
+    """
 
     @abstractmethod
     def leak_bound(self, rates: List[Rate], now: int) -> int:
         """Timestamp below which an item is outside *every* rate's window and so
         may be leaked."""
 
+    @abstractmethod
+    def blocking_offset(self, rate: Rate, weight: int) -> int:
+        """Offset, counting from the *newest* stored item (0-based), of the item
+        whose expiry frees enough room for ``weight`` more units under ``rate``.
+        """
 
-class SlidingWindowLog(Algorithm):
+    @abstractmethod
+    def retry_after(self, rate: Rate, blocking_timestamp: int, now: int) -> int:
+        """Milliseconds from ``now`` until the item at ``blocking_timestamp``
+        has left ``rate``'s window."""
+
+    def decide(
+        self,
+        rates: List[Rate],
+        counts: Sequence[int],
+        weight: int,
+        now: int,
+        peek_timestamp: Callable[[int], Optional[int]],
+    ) -> Decision:
+        """``admit()``, resolving the retry-after in the same step on denial.
+
+        ``peek_timestamp(offset)`` returns the timestamp of the stored item at
+        ``offset`` counting from the newest, or ``None`` if there is no such
+        item. It is only ever called when the item was rejected *and* the weight
+        can fit in principle, so backends pay for the lookup on the slow path
+        only.
+        """
+        decision = self.admit(rates, counts, weight)
+
+        if decision.allowed:
+            return decision
+
+        rate = decision.failing_rate
+        assert rate is not None
+
+        if weight > rate.limit:
+            # Can never fit; waiting() reports -1 and the limiter gives up.
+            return decision
+
+        blocking_timestamp = peek_timestamp(self.blocking_offset(rate, weight))
+
+        if blocking_timestamp is None:
+            # Nothing left to expire - the bucket is already ready.
+            return Decision(failing_rate=rate, retry_after_ms=0)
+
+        return Decision(
+            failing_rate=rate,
+            retry_after_ms=self.retry_after(rate, blocking_timestamp, now),
+        )
+
+
+class SlidingWindowLog(LogAlgorithm):
     """Precise sliding-window-log policy.
 
     Admit while, for every rate, the count of items within its rolling interval
@@ -69,9 +155,24 @@ class SlidingWindowLog(Algorithm):
         for rate, count in zip(rates, counts, strict=True):
             if rate.limit - int(count) < weight:
                 return Decision(failing_rate=rate)
-        return Decision()
+        return ADMITTED
 
     def leak_bound(self, rates: List[Rate], now: int) -> int:
         # rates are sorted ascending by interval (AbstractBucket.rates), so
         # rates[-1] is the widest window.
         return now - rates[-1].interval
+
+    def blocking_offset(self, rate: Rate, weight: int) -> int:
+        # Freeing room for `weight` means evicting the oldest
+        # `weight - (limit - count)` in-window items. Counting from the newest
+        # item instead makes the offset independent of both the count and of
+        # how many expired-but-unleaked items storage still holds.
+        return rate.limit - weight
+
+    def retry_after(self, rate: Rate, blocking_timestamp: int, now: int) -> int:
+        # +1: the window lower bound is inclusive across all backends (an item
+        # counts while timestamp >= now - interval). Returning the bare
+        # difference lands the retry exactly ON the boundary, where the item is
+        # still counted, so the re-put fails and the limiter busy-spins at
+        # delay=0. One extra ms pushes strictly past it.
+        return blocking_timestamp + rate.interval - now + 1

--- a/pyrate_limiter/abstracts/algorithm.py
+++ b/pyrate_limiter/abstracts/algorithm.py
@@ -1,24 +1,13 @@
 """Rate-limiting algorithm abstraction.
 
-Separates the *policy* (which rates admit an item, how long a rejected item must
-wait, and how far back items can be leaked) from the *storage* that counts and
-persists those items. In v4 this is an internal seam: the built-in buckets
-delegate their per-rate admit decision, retry-after and leak bound here, so the
-sliding-window-log logic lives in exactly one place instead of being
-copy-pasted across backends.
+Separates the policy (which rates admit an item, how long a rejected one waits,
+how far back items may be leaked) from the storage that counts and persists
+them. Internal in v4; v5 promotes it to a public extension point.
 
-``Decision`` carries the retry-after alongside the verdict, so a single check
-under a single lock yields both. This matters beyond tidiness: deriving the wait
-afterwards (the pre-4.5 ``AbstractBucket.waiting()`` path) costs a second
-round trip to the backend and reads state that may have changed since the put.
-It is also the prerequisite for algorithms whose state is *not* a log - a token
-bucket or GCRA has no k-th-newest item to look up, and computes its wait in
-closed form.
-
-``LogAlgorithm`` is the sub-interface for policies that do keep a log of
-timestamped items (everything shipped in v4). v5 adds a sibling for
-constant-state policies plus a ``Store`` interface they can share, at which
-point ``Algorithm`` becomes a public extension point.
+Retry-after rides on ``Decision`` so one check under one lock yields both the
+verdict and the wait. Deriving it afterwards costs a second round trip and
+reads state that may have moved - and is impossible for algorithms whose state
+is not a log (token bucket, GCRA), which compute the wait in closed form.
 """
 
 from abc import ABC, abstractmethod
@@ -32,15 +21,10 @@ from .rate import Rate
 class Decision:
     """Outcome of an admit check.
 
-    ``failing_rate is None`` means the item was admitted; otherwise it is the
-    first rate whose window was full.
-
-    ``retry_after_ms`` is how long after the checked item's own timestamp the
-    same weight would fit, or ``None`` when the algorithm could not determine it
-    - either because the weight can never fit (it exceeds ``failing_rate.limit``)
-    or because the backend does not compute it. ``None`` is not "no wait": it
-    means "ask ``AbstractBucket.waiting()``", which falls back to deriving the
-    wait from storage.
+    ``retry_after_ms`` is measured from the checked item's own timestamp.
+    ``None`` means "unknown, ask ``AbstractBucket.waiting()``" - either the
+    weight can never fit, or the backend does not compute a wait. It does not
+    mean "no wait".
     """
 
     failing_rate: Optional[Rate] = None
@@ -51,55 +35,40 @@ class Decision:
         return self.failing_rate is None
 
 
-#: The verdict for an admitted item. ``Decision`` is immutable, so the same
-#: instance is reused on every successful put rather than allocating a fresh one
-#: on the hot path.
+#: Reused on every admit; ``Decision`` is immutable, so the hot path allocates nothing.
 ADMITTED: Final["Decision"] = Decision()
 
 
 class Algorithm(ABC):
-    """A rate-limiting policy, expressed independently of any storage backend.
+    """A rate-limiting policy, independent of any storage backend.
 
-    A bucket supplies the per-rate windowed counts (however it obtains them -
-    in-memory bisect, ``ZCOUNT``, ``COUNT(*) FILTER``...) and the algorithm
-    decides admission. Implementations must be stateless so a single instance
-    can be shared across buckets and threads.
+    Implementations must be stateless so one instance can be shared across
+    buckets and threads.
     """
 
     @abstractmethod
     def admit(self, rates: List[Rate], counts: Sequence[int], weight: int) -> Decision:
-        """Decide whether ``weight`` more items fit, given ``counts[i]`` items
-        already inside ``rates[i]``'s window (``counts`` aligned to ``rates``).
-
-        The returned ``Decision`` carries no retry-after; use ``decide()`` to
-        get both in one step.
-        """
+        """Whether ``weight`` more units fit, given ``counts`` aligned to ``rates``."""
 
 
 class LogAlgorithm(Algorithm):
-    """Policy over storage that keeps one timestamped entry per consumed unit.
+    """Policy over storage holding one timestamped entry per consumed unit.
 
-    Such a policy can answer "when does this become admissible?" by naming the
-    stored entry that has to fall out of the window first - so the retry-after
-    is a lookup plus arithmetic rather than a closed form. Constant-state
-    policies (token bucket, GCRA) will *not* implement this interface.
+    Constant-state policies (token bucket, GCRA) will not implement this.
     """
 
     @abstractmethod
     def leak_bound(self, rates: List[Rate], now: int) -> int:
-        """Timestamp below which an item is outside *every* rate's window and so
-        may be leaked."""
+        """Timestamp below which an item is outside every rate's window."""
 
     @abstractmethod
     def blocking_offset(self, rate: Rate, weight: int) -> int:
-        """Offset, counting from the *newest* stored item (0-based), of the item
-        whose expiry frees enough room for ``weight`` more units under ``rate``.
-        """
+        """Offset from the newest stored item (0-based) of the one whose expiry
+        makes room for ``weight``."""
 
     @abstractmethod
     def retry_after(self, rate: Rate, blocking_timestamp: int, now: int) -> int:
-        """Milliseconds from ``now`` until the item at ``blocking_timestamp``
-        has left ``rate``'s window."""
+        """Milliseconds until ``blocking_timestamp`` leaves ``rate``'s window."""
 
     def decide(
         self,
@@ -111,11 +80,8 @@ class LogAlgorithm(Algorithm):
     ) -> Decision:
         """``admit()``, resolving the retry-after in the same step on denial.
 
-        ``peek_timestamp(offset)`` returns the timestamp of the stored item at
-        ``offset`` counting from the newest, or ``None`` if there is no such
-        item. It is only ever called when the item was rejected *and* the weight
-        can fit in principle, so backends pay for the lookup on the slow path
-        only.
+        ``peek_timestamp(offset)`` is only called on the deny path, so backends
+        pay for the lookup only when it is needed.
         """
         decision = self.admit(rates, counts, weight)
 
@@ -132,7 +98,6 @@ class LogAlgorithm(Algorithm):
         blocking_timestamp = peek_timestamp(self.blocking_offset(rate, weight))
 
         if blocking_timestamp is None:
-            # Nothing left to expire - the bucket is already ready.
             return Decision(failing_rate=rate, retry_after_ms=0)
 
         return Decision(
@@ -142,13 +107,11 @@ class LogAlgorithm(Algorithm):
 
 
 class SlidingWindowLog(LogAlgorithm):
-    """Precise sliding-window-log policy.
+    """Precise sliding-window-log policy: admit while every rate's rolling
+    window stays under its limit.
 
-    Admit while, for every rate, the count of items within its rolling interval
-    stays under the limit. This is PyrateLimiter's default and (until v5) only
-    algorithm; backends may implement it natively for atomicity/performance
-    (Redis Lua, Postgres lock + ``COUNT FILTER``, in-memory bisect) but share
-    this definition of the decision.
+    Backends may implement it natively for atomicity (Redis Lua, Postgres lock
+    + ``COUNT FILTER``, in-memory bisect) but share these definitions.
     """
 
     def admit(self, rates: List[Rate], counts: Sequence[int], weight: int) -> Decision:
@@ -158,21 +121,15 @@ class SlidingWindowLog(LogAlgorithm):
         return ADMITTED
 
     def leak_bound(self, rates: List[Rate], now: int) -> int:
-        # rates are sorted ascending by interval (AbstractBucket.rates), so
-        # rates[-1] is the widest window.
+        # rates sort ascending by interval, so rates[-1] is the widest window.
         return now - rates[-1].interval
 
     def blocking_offset(self, rate: Rate, weight: int) -> int:
-        # Freeing room for `weight` means evicting the oldest
-        # `weight - (limit - count)` in-window items. Counting from the newest
-        # item instead makes the offset independent of both the count and of
-        # how many expired-but-unleaked items storage still holds.
+        # Counting from the newest item keeps this independent of both the
+        # in-window count and any expired-but-unleaked entries still stored.
         return rate.limit - weight
 
     def retry_after(self, rate: Rate, blocking_timestamp: int, now: int) -> int:
-        # +1: the window lower bound is inclusive across all backends (an item
-        # counts while timestamp >= now - interval). Returning the bare
-        # difference lands the retry exactly ON the boundary, where the item is
-        # still counted, so the re-put fails and the limiter busy-spins at
-        # delay=0. One extra ms pushes strictly past it.
+        # +1 clears the inclusive lower bound: landing exactly on it leaves the
+        # item still counted, so the re-put fails and the limiter spins at 0.
         return blocking_timestamp + rate.interval - now + 1

--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -27,18 +27,11 @@ class AbstractBucket(ABC):
     _rates: List[Rate]
     failing_rate: Optional[Rate] = None
     _clock: AbstractClock = MonotonicClock()
-    # The rate-limiting policy this bucket enforces. Internal in v4 (every
-    # bucket uses the sliding-window-log default and delegates its per-rate
-    # admit decision, retry-after and leak bound to it); v5 makes this a
-    # constructor argument so algorithms (GCRA, sliding-window-counter) become
-    # pluggable.
+    # Internal in v4; v5 makes this a constructor argument so algorithms
+    # (GCRA, sliding-window-counter) become pluggable.
     _algorithm: LogAlgorithm = SlidingWindowLog()
-    # Retry-after recorded by the most recent put(), as
-    # ``(weight, absolute_timestamp_at_which_that_weight_fits)``. Kept as an
-    # absolute instant rather than a delay so it stays correct when waiting() is
-    # called with a later timestamp than the put it describes. Every put()
-    # rewrites it and waiting() ignores it unless the weight matches, so a
-    # recorded wait cannot go stale behind a caller's back.
+    # (weight, absolute timestamp at which that weight fits), from the last
+    # put(). Absolute rather than a delay so it survives a later waiting() call.
     _last_wait: Optional[Tuple[int, int]] = None
     # Whether this bucket's operations return awaitables. ``None`` means
     # "unknown" - the Leaker then probes once by calling ``leak(0)`` and
@@ -74,12 +67,10 @@ class AbstractBucket(ABC):
         return self._clock.now()
 
     def _record(self, item: RateItem, decision: Decision) -> bool:
-        """Store a put()'s verdict, and report whether the item was admitted.
+        """Store a put()'s verdict; return whether it was admitted.
 
-        Concrete ``put()`` implementations should funnel their result through
-        here so ``failing_rate`` and the recorded retry-after are always written
-        together. A bucket that sets one without the other can later report a
-        wait that was computed for a different attempt.
+        Every put() path must funnel through here - including trivial admits -
+        so a previous denial can never stay visible.
         """
         self.failing_rate = decision.failing_rate
 
@@ -91,8 +82,7 @@ class AbstractBucket(ABC):
         return decision.allowed
 
     def _recorded_wait(self, item: RateItem) -> Optional[int]:
-        """The retry-after recorded by the last put(), if it was for this same
-        weight; ``None`` when there is nothing usable to reuse."""
+        """Last put()'s retry-after, if it was for this same weight."""
         recorded = self._last_wait
 
         if recorded is None or recorded[0] != item.weight:
@@ -107,16 +97,10 @@ class AbstractBucket(ABC):
         """
 
     def put_decision(self, item: RateItem) -> Union[Decision, Awaitable[Decision]]:
-        """``put()``, returning the full ``Decision`` instead of a bare bool.
+        """``put()``, returning the full ``Decision`` rather than a bare bool.
 
-        This is the forward-compatible way to read a put's outcome: the verdict
-        and the retry-after arrive together, rather than the caller reading the
-        ``failing_rate`` attribute and then calling ``waiting()`` separately.
-        Buckets need not override it - the default reads back what ``put()``
-        recorded.
-
-        ``Decision.retry_after_ms`` is ``None`` for a custom bucket that records
-        no retry-after; call ``waiting()`` for those.
+        Buckets need not override it; the default reads back what ``put()``
+        recorded. ``retry_after_ms`` is ``None`` for buckets that record none.
         """
         result = self.put(item)
 
@@ -175,10 +159,8 @@ class AbstractBucket(ABC):
         if recorded is not None:
             return recorded
 
-        # Fallback for buckets that do not record a decision on put() - custom
-        # backends written against the pre-4.5 contract. Derives the wait by
-        # looking up the item that has to expire first, which costs an extra
-        # round trip and reads storage that may have moved since the put.
+        # Fallback for buckets written against the pre-4.5 contract, which
+        # record nothing: derive the wait with an extra lookup.
         bound_item = self.peek(self._algorithm.blocking_offset(self.failing_rate, item.weight))
 
         if bound_item is None:

--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -8,11 +8,11 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from inspect import isawaitable, iscoroutine
 from threading import Event, Thread
-from typing import Any, Awaitable, Dict, List, Optional, Type, Union
+from typing import Any, Awaitable, Dict, List, Optional, Tuple, Type, Union
 
 from ..clocks import AbstractClock, MonotonicClock
 from ..utils import enforce_rate_list
-from .algorithm import Algorithm, SlidingWindowLog
+from .algorithm import Decision, LogAlgorithm, SlidingWindowLog
 from .rate import Rate, RateItem
 
 logger = logging.getLogger("pyrate_limiter")
@@ -29,9 +29,17 @@ class AbstractBucket(ABC):
     _clock: AbstractClock = MonotonicClock()
     # The rate-limiting policy this bucket enforces. Internal in v4 (every
     # bucket uses the sliding-window-log default and delegates its per-rate
-    # admit decision + leak bound to it); v5 makes this a constructor argument
-    # so algorithms (GCRA, sliding-window-counter) become pluggable.
-    _algorithm: Algorithm = SlidingWindowLog()
+    # admit decision, retry-after and leak bound to it); v5 makes this a
+    # constructor argument so algorithms (GCRA, sliding-window-counter) become
+    # pluggable.
+    _algorithm: LogAlgorithm = SlidingWindowLog()
+    # Retry-after recorded by the most recent put(), as
+    # ``(weight, absolute_timestamp_at_which_that_weight_fits)``. Kept as an
+    # absolute instant rather than a delay so it stays correct when waiting() is
+    # called with a later timestamp than the put it describes. Every put()
+    # rewrites it and waiting() ignores it unless the weight matches, so a
+    # recorded wait cannot go stale behind a caller's back.
+    _last_wait: Optional[Tuple[int, int]] = None
     # Whether this bucket's operations return awaitables. ``None`` means
     # "unknown" - the Leaker then probes once by calling ``leak(0)`` and
     # checking for a coroutine. Built-in sync/async buckets declare this so no
@@ -65,11 +73,68 @@ class AbstractBucket(ABC):
         """Retrieve current timestamp from the clock backend."""
         return self._clock.now()
 
+    def _record(self, item: RateItem, decision: Decision) -> bool:
+        """Store a put()'s verdict, and report whether the item was admitted.
+
+        Concrete ``put()`` implementations should funnel their result through
+        here so ``failing_rate`` and the recorded retry-after are always written
+        together. A bucket that sets one without the other can later report a
+        wait that was computed for a different attempt.
+        """
+        self.failing_rate = decision.failing_rate
+
+        if decision.retry_after_ms is None:
+            self._last_wait = None
+        else:
+            self._last_wait = (item.weight, item.timestamp + decision.retry_after_ms)
+
+        return decision.allowed
+
+    def _recorded_wait(self, item: RateItem) -> Optional[int]:
+        """The retry-after recorded by the last put(), if it was for this same
+        weight; ``None`` when there is nothing usable to reuse."""
+        recorded = self._last_wait
+
+        if recorded is None or recorded[0] != item.weight:
+            return None
+
+        return max(0, recorded[1] - item.timestamp)
+
     @abstractmethod
     def put(self, item: RateItem) -> Union[bool, Awaitable[bool]]:
         """Put an item (typically the current time) in the bucket
         return true if successful, otherwise false
         """
+
+    def put_decision(self, item: RateItem) -> Union[Decision, Awaitable[Decision]]:
+        """``put()``, returning the full ``Decision`` instead of a bare bool.
+
+        This is the forward-compatible way to read a put's outcome: the verdict
+        and the retry-after arrive together, rather than the caller reading the
+        ``failing_rate`` attribute and then calling ``waiting()`` separately.
+        Buckets need not override it - the default reads back what ``put()``
+        recorded.
+
+        ``Decision.retry_after_ms`` is ``None`` for a custom bucket that records
+        no retry-after; call ``waiting()`` for those.
+        """
+        result = self.put(item)
+
+        if isawaitable(result):
+
+            async def _await_decision() -> Decision:
+                await result
+                return self._decision(item)
+
+            return _await_decision()
+
+        return self._decision(item)
+
+    def _decision(self, item: RateItem) -> Decision:
+        if item.weight == 0 or self.failing_rate is None:
+            return Decision()
+
+        return Decision(failing_rate=self.failing_rate, retry_after_ms=self._recorded_wait(item))
 
     @abstractmethod
     def leak(
@@ -105,7 +170,16 @@ class AbstractBucket(ABC):
         if item.weight > self.failing_rate.limit:
             return -1
 
-        bound_item = self.peek(self.failing_rate.limit - item.weight)
+        recorded = self._recorded_wait(item)
+
+        if recorded is not None:
+            return recorded
+
+        # Fallback for buckets that do not record a decision on put() - custom
+        # backends written against the pre-4.5 contract. Derives the wait by
+        # looking up the item that has to expire first, which costs an extra
+        # round trip and reads storage that may have moved since the put.
+        bound_item = self.peek(self._algorithm.blocking_offset(self.failing_rate, item.weight))
 
         if bound_item is None:
             # NOTE: No waiting, bucket is immediately ready
@@ -113,14 +187,7 @@ class AbstractBucket(ABC):
 
         def _calc_waiting(inner_bound_item: RateItem) -> int:
             assert self.failing_rate is not None  # NOTE: silence mypy
-            lower_time_bound = item.timestamp - self.failing_rate.interval
-            upper_time_bound = inner_bound_item.timestamp
-            # +1: the window lower bound is inclusive across all backends (an
-            # item counts while timestamp >= now - interval). Returning the bare
-            # difference lands the retry exactly ON the boundary, where the item
-            # is still counted, so the re-put fails and waiting() then returns 0
-            # -> _delay_waiter busy-spins. One extra ms pushes strictly past it.
-            return upper_time_bound - lower_time_bound + 1
+            return self._algorithm.retry_after(self.failing_rate, inner_bound_item.timestamp, item.timestamp)
 
         async def _calc_waiting_async() -> int:
             nonlocal bound_item

--- a/pyrate_limiter/abstracts/wrappers.py
+++ b/pyrate_limiter/abstracts/wrappers.py
@@ -79,8 +79,8 @@ class BucketAsyncWrapper(AbstractBucket):
 
     @property
     def _last_wait(self):
-        # waiting() is inherited from AbstractBucket and reads these off `self`;
-        # delegate so it sees what the *wrapped* bucket recorded on put().
+        # Inherited waiting() reads these off `self`; point them at the wrapped
+        # bucket, which is what actually records on put().
         return self.bucket._last_wait
 
     @property

--- a/pyrate_limiter/abstracts/wrappers.py
+++ b/pyrate_limiter/abstracts/wrappers.py
@@ -78,6 +78,16 @@ class BucketAsyncWrapper(AbstractBucket):
         return self.bucket.failing_rate
 
     @property
+    def _last_wait(self):
+        # waiting() is inherited from AbstractBucket and reads these off `self`;
+        # delegate so it sees what the *wrapped* bucket recorded on put().
+        return self.bucket._last_wait
+
+    @property
+    def _algorithm(self):
+        return self.bucket._algorithm
+
+    @property
     def rates(self):
         return self.bucket.rates
 

--- a/pyrate_limiter/buckets/in_memory_bucket.py
+++ b/pyrate_limiter/buckets/in_memory_bucket.py
@@ -40,7 +40,8 @@ class InMemoryBucket(AbstractBucket):
 
     def put(self, item: RateItem) -> bool:
         if item.weight == 0:
-            return True
+            with self._lock:
+                return self._record(item, ADMITTED)
 
         with self._lock:
             # In-memory native implementation of the SlidingWindowLog policy
@@ -63,10 +64,8 @@ class InMemoryBucket(AbstractBucket):
                 space_available = rate.limit - count_existing_items
 
                 if space_available < item.weight:
-                    # Denied. The item that has to expire first is a constant
-                    # offset from the newest one, so the retry-after falls out
-                    # of the bisect already done here - record it with the
-                    # verdict rather than making waiting() peek again.
+                    # The blocking item is a fixed offset from the newest, so
+                    # the wait falls out of the bisect already done here.
                     offset = self._algorithm.blocking_offset(rate, item.weight)
                     blocking_idx = current_length - 1 - offset
                     retry_after = None

--- a/pyrate_limiter/buckets/in_memory_bucket.py
+++ b/pyrate_limiter/buckets/in_memory_bucket.py
@@ -5,6 +5,7 @@ from operator import attrgetter
 from threading import RLock
 from typing import List, Optional
 
+from ..abstracts.algorithm import ADMITTED, Decision
 from ..abstracts.bucket import AbstractBucket
 from ..abstracts.rate import Rate, RateItem
 
@@ -62,10 +63,24 @@ class InMemoryBucket(AbstractBucket):
                 space_available = rate.limit - count_existing_items
 
                 if space_available < item.weight:
-                    self.failing_rate = rate
-                    return False
+                    # Denied. The item that has to expire first is a constant
+                    # offset from the newest one, so the retry-after falls out
+                    # of the bisect already done here - record it with the
+                    # verdict rather than making waiting() peek again.
+                    offset = self._algorithm.blocking_offset(rate, item.weight)
+                    blocking_idx = current_length - 1 - offset
+                    retry_after = None
 
-            self.failing_rate = None
+                    if 0 <= blocking_idx < current_length:
+                        retry_after = self._algorithm.retry_after(
+                            rate,
+                            self.items[blocking_idx].timestamp,
+                            item.timestamp,
+                        )
+
+                    return self._record(item, Decision(failing_rate=rate, retry_after_ms=retry_after))
+
+            self._record(item, ADMITTED)
 
             if item.weight > 1:
                 self.items.extend([item for _ in range(item.weight)])
@@ -97,6 +112,7 @@ class InMemoryBucket(AbstractBucket):
     def flush(self) -> None:
         with self._lock:
             self.failing_rate = None
+            self._last_wait = None
             del self.items[:]
 
     def count(self) -> int:

--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Awaitable, List, Optional, Union
 
 from ..abstracts import AbstractBucket, Rate, RateItem
-from ..abstracts.algorithm import Decision
+from ..abstracts.algorithm import ADMITTED, Decision
 from ..clocks import PostgresClock
 
 logger = logging.getLogger(__name__)
@@ -125,7 +125,7 @@ class PostgresBucket(AbstractBucket):
         from psycopg.errors import LockNotAvailable
 
         if item.weight == 0:
-            return True
+            return self._record(item, ADMITTED)
 
         item_ts_seconds = item.timestamp / 1000
 
@@ -145,8 +145,7 @@ class PostgresBucket(AbstractBucket):
                 conn.execute(self._q_lock)
             except LockNotAvailable:
                 logger.debug("LockNotAvailable")
-                # Contention, not a full window: there is no meaningful
-                # retry-after to record, so waiting() falls back to deriving one.
+                # Contention, not a full window - no meaningful wait to record.
                 self._record(item, Decision(failing_rate=self.rates[0]))
                 return False
 
@@ -156,8 +155,7 @@ class PostgresBucket(AbstractBucket):
             cur.close()
 
             def peek_timestamp(offset: int) -> Optional[int]:
-                # Runs inside the EXCLUSIVE table lock, so the retry-after
-                # describes exactly the state the verdict was made against.
+                # Inside the EXCLUSIVE lock: same state the verdict saw.
                 peek_cur = conn.execute(self._q_peek, (offset,))
                 peek_row = peek_cur.fetchone()
                 peek_cur.close()

--- a/pyrate_limiter/buckets/postgres.py
+++ b/pyrate_limiter/buckets/postgres.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Awaitable, List, Optional, Union
 
 from ..abstracts import AbstractBucket, Rate, RateItem
+from ..abstracts.algorithm import Decision
 from ..clocks import PostgresClock
 
 logger = logging.getLogger(__name__)
@@ -144,7 +145,9 @@ class PostgresBucket(AbstractBucket):
                 conn.execute(self._q_lock)
             except LockNotAvailable:
                 logger.debug("LockNotAvailable")
-                self.failing_rate = self.rates[0]
+                # Contention, not a full window: there is no meaningful
+                # retry-after to record, so waiting() falls back to deriving one.
+                self._record(item, Decision(failing_rate=self.rates[0]))
                 return False
 
             params = [v for rate in self.rates for v in (item_ts_seconds, rate.interval)]
@@ -152,12 +155,25 @@ class PostgresBucket(AbstractBucket):
             counts = cur.fetchone()
             cur.close()
 
-            decision = self._algorithm.admit(self.rates, counts, item.weight)
-            if not decision.allowed:
-                self.failing_rate = decision.failing_rate
-                return False
+            def peek_timestamp(offset: int) -> Optional[int]:
+                # Runs inside the EXCLUSIVE table lock, so the retry-after
+                # describes exactly the state the verdict was made against.
+                peek_cur = conn.execute(self._q_peek, (offset,))
+                peek_row = peek_cur.fetchone()
+                peek_cur.close()
 
-            self.failing_rate = None
+                return None if peek_row is None else int(peek_row[2])
+
+            decision = self._algorithm.decide(
+                self.rates,
+                counts,
+                item.weight,
+                item.timestamp,
+                peek_timestamp,
+            )
+
+            if not self._record(item, decision):
+                return False
             # Insert all `weight` unit-rows in a single statement (one round
             # trip) instead of `weight` separate INSERTs under the table lock.
             conn.execute(self._q_put, (item.name, item.weight, item_ts_seconds, item.weight))
@@ -195,6 +211,7 @@ class PostgresBucket(AbstractBucket):
         with self._get_conn() as conn:
             conn.execute(self._q_flush)
             self.failing_rate = None
+            self._last_wait = None
 
         return None
 

--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
     from redis.asyncio import Redis as AsyncRedis
 
 
+# Sentinels PUT_ITEM returns in place of a blocking timestamp.
+NEVER_FITS = -1  # weight exceeds the rate's limit; nothing can make room
+NO_BLOCKING_ITEM = -2  # window full but no item to wait on; already ready
+
+
 class LuaScript:
     """Scripts that deal with bucket operations"""
 
@@ -32,12 +37,15 @@ class LuaScript:
         local count = redis.call('ZCOUNT', bucket, now - interval, now)
         local space_available = limit - tonumber(count)
         if space_available < space_required then
-            -- Blocking item sits `limit - space_required` places from the
-            -- newest. Negative rank = weight can never fit; -1 means no wait.
-            local blocking_timestamp = -1
+            -- Blocking item sits `limit - space_required` places from the newest.
+            -- Denial implies count > rank, so the ZRANGE cannot come back empty;
+            -- -2 keeps that case distinguishable from -1 rather than silently
+            -- reading as "never fits".
             local rank = limit - space_required
+            local blocking_timestamp = -1
 
             if rank >= 0 then
+                blocking_timestamp = -2
                 local blocking = redis.call('ZRANGE', bucket, -1 - rank, -1 - rank, 'WITHSCORES')
                 if blocking[2] then
                     blocking_timestamp = tonumber(blocking[2])
@@ -148,9 +156,13 @@ class RedisBucket(AbstractBucket):
 
             rate = self.rates[idx]
 
-            if blocking_timestamp < 0:
-                # Weight exceeds the limit; waiting() reports -1.
+            if blocking_timestamp == NEVER_FITS:
+                # waiting() reports -1 and the limiter gives up.
                 return Decision(failing_rate=rate)
+
+            if blocking_timestamp == NO_BLOCKING_ITEM:
+                # Match LogAlgorithm.decide()'s peek_timestamp -> None mapping.
+                return Decision(failing_rate=rate, retry_after_ms=0)
 
             return Decision(
                 failing_rate=rate,

--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -7,6 +7,7 @@ from time import time_ns
 from typing import TYPE_CHECKING, Awaitable, List, Optional, Tuple, Union
 
 from ..abstracts import AbstractBucket, Rate, RateItem
+from ..abstracts.algorithm import ADMITTED, Decision
 from ..utils import id_generator
 
 if TYPE_CHECKING:
@@ -31,7 +32,22 @@ class LuaScript:
         local count = redis.call('ZCOUNT', bucket, now - interval, now)
         local space_available = limit - tonumber(count)
         if space_available < space_required then
-            return i - 1
+            -- Resolve the retry-after in the same atomic script as the verdict.
+            -- The item that has to expire first sits `limit - space_required`
+            -- places from the newest; a negative rank means the weight can never
+            -- fit under this rate, and -1 tells the caller there is no wait to
+            -- report.
+            local blocking_timestamp = -1
+            local rank = limit - space_required
+
+            if rank >= 0 then
+                local blocking = redis.call('ZRANGE', bucket, -1 - rank, -1 - rank, 'WITHSCORES')
+                if blocking[2] then
+                    blocking_timestamp = tonumber(blocking[2])
+                end
+            end
+
+            return {i - 1, blocking_timestamp}
         end
     end
 
@@ -53,7 +69,7 @@ class LuaScript:
         redis.call('ZADD', bucket, unpack(batch))
     end
 
-    return -1
+    return {-1, -1}
     """
 
 
@@ -108,7 +124,14 @@ class RedisBucket(AbstractBucket):
 
         return cls(rates, redis, bucket_key, script_hash)
 
-    def _check_and_insert(self, item: RateItem) -> Union[Rate, None, Awaitable[Optional[Rate]]]:
+    def _check_and_insert(self, item: RateItem) -> Union[Decision, Awaitable[Decision]]:
+        """Run the check-and-insert script, returning the full verdict.
+
+        The script reports both the failing rate index and the timestamp of the
+        item blocking it, so the retry-after comes back from the same atomic
+        evaluation as the decision - no second ZRANGE round trip, and no window
+        for the sorted set to move in between.
+        """
         keys = [self.bucket_key]
 
         args = [
@@ -120,36 +143,44 @@ class RedisBucket(AbstractBucket):
             *[value for rate in self.rates for value in (rate.interval, rate.limit)],
         ]
 
-        idx = self.redis.evalsha(self.script_hash, len(keys), *keys, *args)
+        reply = self.redis.evalsha(self.script_hash, len(keys), *keys, *args)
 
-        def _handle_sync(returned_idx: int):
-            assert isinstance(returned_idx, int), "Not int"
-            if returned_idx < 0:
-                return None
+        def _handle_sync(returned: List[int]) -> Decision:
+            idx, blocking_timestamp = int(returned[0]), int(returned[1])
 
-            return self.rates[returned_idx]
+            if idx < 0:
+                return ADMITTED
 
-        async def _handle_async(returned_idx: Awaitable[int]):
-            assert isawaitable(returned_idx), "Not corotine"
-            awaited_idx = await returned_idx
-            return _handle_sync(awaited_idx)
+            rate = self.rates[idx]
 
-        return _handle_async(idx) if isawaitable(idx) else _handle_sync(idx)
+            if blocking_timestamp < 0:
+                # The weight exceeds this rate's limit, so nothing expiring can
+                # ever make room; waiting() reports -1 from the weight check.
+                return Decision(failing_rate=rate)
+
+            return Decision(
+                failing_rate=rate,
+                retry_after_ms=self._algorithm.retry_after(rate, blocking_timestamp, item.timestamp),
+            )
+
+        async def _handle_async(pending: Awaitable[List[int]]) -> Decision:
+            return _handle_sync(await pending)
+
+        return _handle_async(reply) if isawaitable(reply) else _handle_sync(reply)
 
     def put(self, item: RateItem) -> Union[bool, Awaitable[bool]]:
         """Add item to key"""
-        failing_rate = self._check_and_insert(item)
-        if isawaitable(failing_rate):
+        decision = self._check_and_insert(item)
+
+        if isawaitable(decision):
 
             async def _handle_async():
-                self.failing_rate = await failing_rate
-                return not bool(self.failing_rate)
+                return self._record(item, await decision)
 
             return _handle_async()
 
-        assert isinstance(failing_rate, Rate) or failing_rate is None
-        self.failing_rate = failing_rate
-        return not bool(self.failing_rate)
+        assert isinstance(decision, Decision)
+        return self._record(item, decision)
 
     def leak(self, current_timestamp: Optional[int] = None) -> Union[int, Awaitable[int]]:
         assert current_timestamp is not None
@@ -161,6 +192,7 @@ class RedisBucket(AbstractBucket):
 
     def flush(self):
         self.failing_rate = None
+        self._last_wait = None
         return self.redis.delete(self.bucket_key)
 
     def count(self):

--- a/pyrate_limiter/buckets/redis_bucket.py
+++ b/pyrate_limiter/buckets/redis_bucket.py
@@ -32,11 +32,8 @@ class LuaScript:
         local count = redis.call('ZCOUNT', bucket, now - interval, now)
         local space_available = limit - tonumber(count)
         if space_available < space_required then
-            -- Resolve the retry-after in the same atomic script as the verdict.
-            -- The item that has to expire first sits `limit - space_required`
-            -- places from the newest; a negative rank means the weight can never
-            -- fit under this rate, and -1 tells the caller there is no wait to
-            -- report.
+            -- Blocking item sits `limit - space_required` places from the
+            -- newest. Negative rank = weight can never fit; -1 means no wait.
             local blocking_timestamp = -1
             local rank = limit - space_required
 
@@ -125,12 +122,10 @@ class RedisBucket(AbstractBucket):
         return cls(rates, redis, bucket_key, script_hash)
 
     def _check_and_insert(self, item: RateItem) -> Union[Decision, Awaitable[Decision]]:
-        """Run the check-and-insert script, returning the full verdict.
+        """Check-and-insert, returning the full verdict.
 
-        The script reports both the failing rate index and the timestamp of the
-        item blocking it, so the retry-after comes back from the same atomic
-        evaluation as the decision - no second ZRANGE round trip, and no window
-        for the sorted set to move in between.
+        The script returns the blocking timestamp alongside the failing rate, so
+        the wait comes from the same atomic evaluation - no second ZRANGE.
         """
         keys = [self.bucket_key]
 
@@ -154,8 +149,7 @@ class RedisBucket(AbstractBucket):
             rate = self.rates[idx]
 
             if blocking_timestamp < 0:
-                # The weight exceeds this rate's limit, so nothing expiring can
-                # ever make room; waiting() reports -1 from the weight check.
+                # Weight exceeds the limit; waiting() reports -1.
                 return Decision(failing_rate=rate)
 
             return Decision(

--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -141,11 +141,10 @@ class SQLiteBucket(AbstractBucket):
             return True
 
     def _peek_timestamp(self, offset: int) -> Optional[int]:
-        """Timestamp of the item ``offset`` places from the newest, or ``None``.
+        """Timestamp ``offset`` places from the newest item, or ``None``.
 
-        Only called on the deny path, and always from inside put()'s lock hold,
-        so the retry-after describes the same rows the verdict was made against
-        - the background Leaker cannot delete any in between.
+        Called from inside put()'s lock hold, so the Leaker cannot delete rows
+        between the verdict and the wait.
         """
         cur = self.conn.execute(Queries.PEEK.format(table=self.table, count=offset))
         row = cur.fetchone()

--- a/pyrate_limiter/buckets/sqlite_bucket.py
+++ b/pyrate_limiter/buckets/sqlite_bucket.py
@@ -121,9 +121,15 @@ class SQLiteBucket(AbstractBucket):
                 assert interval == rate.interval
                 counts.append(count)
 
-            decision = self._algorithm.admit(self.rates, counts, item.weight)
-            if not decision.allowed:
-                self.failing_rate = decision.failing_rate
+            decision = self._algorithm.decide(
+                self.rates,
+                counts,
+                item.weight,
+                item.timestamp,
+                self._peek_timestamp,
+            )
+
+            if not self._record(item, decision):
                 return False
 
             # Bind name + timestamp as parameters; never interpolate the
@@ -133,6 +139,19 @@ class SQLiteBucket(AbstractBucket):
             self.conn.executemany(query, rows).close()
             self.conn.commit()
             return True
+
+    def _peek_timestamp(self, offset: int) -> Optional[int]:
+        """Timestamp of the item ``offset`` places from the newest, or ``None``.
+
+        Only called on the deny path, and always from inside put()'s lock hold,
+        so the retry-after describes the same rows the verdict was made against
+        - the background Leaker cannot delete any in between.
+        """
+        cur = self.conn.execute(Queries.PEEK.format(table=self.table, count=offset))
+        row = cur.fetchone()
+        cur.close()
+
+        return None if row is None else int(row[1])
 
     def leak(self, current_timestamp: Optional[int] = None) -> int:
         """Leaking/clean up bucket"""
@@ -160,6 +179,7 @@ class SQLiteBucket(AbstractBucket):
             self.conn.execute(Queries.FLUSH.format(table=self.table)).close()
             self.conn.commit()
             self.failing_rate = None
+            self._last_wait = None
 
     def count(self) -> int:
         with self.lock:

--- a/tests/test_bucket_all.py
+++ b/tests/test_bucket_all.py
@@ -195,14 +195,11 @@ async def test_bucket_waiting(create_bucket):
 
 @pytest.mark.asyncio
 async def test_bucket_records_retry_after(create_bucket):
-    """Every backend must record the wait on put(), and it must agree with the
-    value derived from storage - the fallback `waiting()` uses for buckets that
-    record nothing."""
+    """put() records the wait, and it agrees with deriving it from storage."""
     rates = [Rate(3, 1000)]
     bucket = BucketAsyncWrapper(await create_bucket(rates))
 
     async def derived_wait(item: RateItem) -> int:
-        """The pre-4.5 derivation, recomputed straight from storage."""
         rate = bucket.failing_rate
         assert rate is not None
         bound = await bucket.peek(rate.limit - item.weight)
@@ -220,13 +217,11 @@ async def test_bucket_records_retry_after(create_bucket):
     blocked = RateItem("item", now + 30)
     assert await bucket.put(blocked) is False
 
-    # put() recorded a wait...
     decision = await bucket.put_decision(RateItem("item", now + 30))
     assert decision.failing_rate == rates[0]
     assert decision.retry_after_ms is not None
     assert decision.retry_after_ms > 0
 
-    # ...and it matches what deriving from storage would have produced.
     assert await bucket.waiting(blocked) == await derived_wait(blocked)
 
     # A successful put clears the standing denial on every backend.

--- a/tests/test_bucket_all.py
+++ b/tests/test_bucket_all.py
@@ -194,6 +194,50 @@ async def test_bucket_waiting(create_bucket):
 
 
 @pytest.mark.asyncio
+async def test_bucket_records_retry_after(create_bucket):
+    """Every backend must record the wait on put(), and it must agree with the
+    value derived from storage - the fallback `waiting()` uses for buckets that
+    record nothing."""
+    rates = [Rate(3, 1000)]
+    bucket = BucketAsyncWrapper(await create_bucket(rates))
+
+    async def derived_wait(item: RateItem) -> int:
+        """The pre-4.5 derivation, recomputed straight from storage."""
+        rate = bucket.failing_rate
+        assert rate is not None
+        bound = await bucket.peek(rate.limit - item.weight)
+
+        if bound is None:
+            return 0
+
+        return bound.timestamp - (item.timestamp - rate.interval) + 1
+
+    now = await get_now(bucket)
+
+    for offset in (0, 10, 20):
+        assert await bucket.put(RateItem("item", now + offset)) is True
+
+    blocked = RateItem("item", now + 30)
+    assert await bucket.put(blocked) is False
+
+    # put() recorded a wait...
+    decision = await bucket.put_decision(RateItem("item", now + 30))
+    assert decision.failing_rate == rates[0]
+    assert decision.retry_after_ms is not None
+    assert decision.retry_after_ms > 0
+
+    # ...and it matches what deriving from storage would have produced.
+    assert await bucket.waiting(blocked) == await derived_wait(blocked)
+
+    # A successful put clears the standing denial on every backend.
+    await asyncio.sleep(1.1)
+    admitted = RateItem("item", await get_now(bucket))
+    assert await bucket.put(admitted) is True
+    assert bucket.failing_rate is None
+    assert (await bucket.put_decision(RateItem("item", await get_now(bucket)))).allowed is True
+
+
+@pytest.mark.asyncio
 async def test_bucket_leak(create_bucket):
     rates = [Rate(100, 3000)]
     bucket = BucketAsyncWrapper(await create_bucket(rates))

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -1,0 +1,288 @@
+"""Retry-after carried on `Decision` (Phase A).
+
+`put()` now records the wait alongside the verdict, so `waiting()` can answer
+without a second lookup into storage. These tests pin the recorded value to the
+pre-4.5 derivation it replaces, check that the fallback still works for buckets
+that record nothing, and cover the cases where a recorded wait must be ignored.
+"""
+from typing import List, Optional
+
+import pytest
+
+from pyrate_limiter import Decision, InMemoryBucket, Rate, RateItem
+from pyrate_limiter.abstracts.algorithm import ADMITTED, SlidingWindowLog
+
+
+def legacy_waiting(bucket, item: RateItem) -> int:
+    """The pre-4.5 derivation of the wait, kept here as the reference.
+
+    Looks up the item that must expire first and measures it against the
+    window's inclusive lower bound. `waiting()` no longer computes this on the
+    happy path, so it is reproduced verbatim to cross-check what put() records.
+    """
+    rate = bucket.failing_rate
+
+    if rate is None:
+        return 0
+
+    if item.weight > rate.limit:
+        return -1
+
+    bound_item = bucket.peek(rate.limit - item.weight)
+
+    if bound_item is None:
+        return 0
+
+    return bound_item.timestamp - (item.timestamp - rate.interval) + 1
+
+
+# --------------------------------------------------------------- Decision
+
+def test_decision_defaults():
+    assert Decision().retry_after_ms is None
+    assert Decision().allowed is True
+    assert ADMITTED.allowed is True
+    assert ADMITTED.retry_after_ms is None
+
+
+def test_decision_carries_retry_after():
+    rate = Rate(3, 1000)
+    denied = Decision(failing_rate=rate, retry_after_ms=250)
+    assert denied.allowed is False
+    assert denied.failing_rate is rate
+    assert denied.retry_after_ms == 250
+
+
+# ------------------------------------------------------- LogAlgorithm.decide
+
+def test_blocking_offset_and_retry_after():
+    algo = SlidingWindowLog()
+    rate = Rate(5, 1000)
+    # Freeing room for `weight` means waiting on the item `limit - weight`
+    # places from the newest.
+    assert algo.blocking_offset(rate, 1) == 4
+    assert algo.blocking_offset(rate, 5) == 0
+    # +1 clears the inclusive lower bound.
+    assert algo.retry_after(rate, blocking_timestamp=500, now=1200) == 301
+
+
+def test_decide_skips_lookup_when_admitted():
+    algo = SlidingWindowLog()
+    rates = [Rate(3, 1000)]
+
+    def boom(_offset):
+        raise AssertionError("decide() must not look up storage when admitting")
+
+    decision = algo.decide(rates, [0], weight=1, now=1000, peek_timestamp=boom)
+    assert decision.allowed
+    assert decision.retry_after_ms is None
+
+
+def test_decide_skips_lookup_when_weight_can_never_fit():
+    algo = SlidingWindowLog()
+    rates = [Rate(3, 1000)]
+
+    def boom(_offset):
+        raise AssertionError("decide() must not look up storage for an impossible weight")
+
+    decision = algo.decide(rates, [0], weight=4, now=1000, peek_timestamp=boom)
+    assert not decision.allowed
+    # None, not 0: waiting() reports -1 for a weight that exceeds the limit.
+    assert decision.retry_after_ms is None
+
+
+def test_decide_resolves_retry_after_on_denial():
+    algo = SlidingWindowLog()
+    rates = [Rate(3, 1000)]
+    seen: List[int] = []
+
+    def peek(offset: int) -> Optional[int]:
+        seen.append(offset)
+        return 700
+
+    decision = algo.decide(rates, [3], weight=1, now=1200, peek_timestamp=peek)
+    assert seen == [2]  # limit 3 - weight 1
+    assert decision.failing_rate is rates[0]
+    assert decision.retry_after_ms == 700 + 1000 - 1200 + 1
+
+
+def test_decide_reports_zero_when_nothing_left_to_expire():
+    algo = SlidingWindowLog()
+    decision = algo.decide([Rate(3, 1000)], [3], weight=1, now=1200, peek_timestamp=lambda _o: None)
+    assert not decision.allowed
+    assert decision.retry_after_ms == 0
+
+
+# --------------------------------------------------- recorded wait on buckets
+
+@pytest.mark.parametrize(
+    "rates",
+    [
+        [Rate(1, 100)],
+        [Rate(3, 1000)],
+        [Rate(3, 1000), Rate(5, 5000)],
+        [Rate(10, 1000), Rate(20, 10000)],
+    ],
+    ids=["tiny", "single", "two-rates", "wide"],
+)
+@pytest.mark.parametrize("weight", [1, 2, 3])
+def test_recorded_wait_matches_legacy_derivation(rates, weight):
+    """What put() records must equal what waiting() used to derive."""
+    bucket = InMemoryBucket(rates)
+    denials = 0
+
+    for step in range(40):
+        item = RateItem("x", 100_000 + step * 37, weight=weight)
+
+        if bucket.put(item):
+            continue
+
+        denials += 1
+        assert bucket.waiting(item) == legacy_waiting(bucket, item)
+
+    assert denials > 0, "scenario never exercised the denial path"
+
+
+def test_waiting_does_not_touch_storage_when_put_recorded_a_wait():
+    bucket = InMemoryBucket([Rate(2, 1000)])
+    assert bucket.put(RateItem("a", 1000)) is True
+    assert bucket.put(RateItem("a", 1100)) is True
+
+    item = RateItem("a", 1200)
+    assert bucket.put(item) is False
+
+    def boom(_index):
+        raise AssertionError("waiting() must not peek when put() recorded a wait")
+
+    bucket.peek = boom  # type: ignore[method-assign]
+    # Blocking item is 1 place from the newest -> ts 1000.
+    assert bucket.waiting(item) == 1000 + 1000 - 1200 + 1
+
+
+def test_recorded_wait_is_not_reused_for_a_different_weight():
+    bucket = InMemoryBucket([Rate(3, 1000)])
+
+    for ts in (1000, 1100, 1200):
+        assert bucket.put(RateItem("a", ts)) is True
+
+    light = RateItem("a", 1300, weight=1)
+    assert bucket.put(light) is False
+    assert bucket.waiting(light) == 1000 + 1000 - 1300 + 1  # 701
+
+    # A heavier item must wait on a *different* stored item, so the recording
+    # made for weight 1 has to be ignored rather than reused.
+    heavy = RateItem("a", 1300, weight=2)
+    assert bucket.waiting(heavy) == 1100 + 1000 - 1300 + 1  # 801
+    assert bucket.waiting(heavy) == legacy_waiting(bucket, heavy)
+
+
+def test_recorded_wait_survives_a_later_query_timestamp():
+    """The recording is an absolute instant, so a later query shrinks the wait."""
+    bucket = InMemoryBucket([Rate(1, 1000)])
+    assert bucket.put(RateItem("a", 1000)) is True
+
+    item = RateItem("a", 1000)
+    assert bucket.put(item) is False
+    assert bucket.waiting(item) == 1001
+
+    assert bucket.waiting(RateItem("a", 1500)) == 501
+    # Past the point where it fits, the wait floors at 0 rather than going negative.
+    assert bucket.waiting(RateItem("a", 9000)) == 0
+
+
+def test_successful_put_clears_the_recorded_wait():
+    bucket = InMemoryBucket([Rate(1, 100)])
+    assert bucket.put(RateItem("a", 1000)) is True
+
+    denied = RateItem("a", 1000)
+    assert bucket.put(denied) is False
+    assert bucket.failing_rate is not None
+    assert bucket._last_wait is not None
+
+    assert bucket.put(RateItem("a", 2000)) is True
+    assert bucket.failing_rate is None
+    assert bucket._last_wait is None
+    assert bucket.waiting(denied) == 0
+
+
+# ------------------------------------------------------------- put_decision
+
+def test_put_decision_on_success():
+    bucket = InMemoryBucket([Rate(2, 1000)])
+    decision = bucket.put_decision(RateItem("a", 1000))
+    assert isinstance(decision, Decision)
+    assert decision.allowed
+    assert decision.failing_rate is None
+
+
+def test_put_decision_on_denial_carries_the_wait():
+    rates = [Rate(1, 1000)]
+    bucket = InMemoryBucket(rates)
+    assert bucket.put(RateItem("a", 1000)) is True
+
+    decision = bucket.put_decision(RateItem("a", 1200))
+    assert isinstance(decision, Decision)
+    assert not decision.allowed
+    assert decision.failing_rate is rates[0]
+    assert decision.retry_after_ms == 1000 + 1000 - 1200 + 1
+
+
+def test_put_decision_for_a_weightless_item():
+    bucket = InMemoryBucket([Rate(1, 1000)])
+    assert bucket.put(RateItem("a", 1000)) is True
+    assert bucket.put(RateItem("a", 1000)) is False
+
+    # A weightless item is always admitted, so it must not inherit the standing
+    # denial left behind by the previous put.
+    decision = bucket.put_decision(RateItem("a", 1000, weight=0))
+    assert isinstance(decision, Decision)
+    assert decision.allowed
+
+
+def test_put_decision_reports_no_wait_for_an_impossible_weight():
+    rates = [Rate(2, 1000)]
+    bucket = InMemoryBucket(rates)
+
+    decision = bucket.put_decision(RateItem("a", 1000, weight=5))
+    assert isinstance(decision, Decision)
+    assert not decision.allowed
+    assert decision.failing_rate is rates[0]
+    assert decision.retry_after_ms is None
+    assert bucket.waiting(RateItem("a", 1000, weight=5)) == -1
+
+
+# ------------------------------------------------- fallback for custom buckets
+
+class LegacyBucket(InMemoryBucket):
+    """A bucket written against the pre-4.5 contract: sets `failing_rate` on
+    denial and records no retry-after."""
+
+    def put(self, item: RateItem) -> bool:
+        admitted = super().put(item)
+        # Drop the recording, keeping only the old side-channel.
+        self._last_wait = None
+        return admitted
+
+
+def test_waiting_falls_back_to_storage_when_nothing_was_recorded():
+    bucket = LegacyBucket([Rate(2, 1000)])
+    assert bucket.put(RateItem("a", 1000)) is True
+    assert bucket.put(RateItem("a", 1100)) is True
+
+    item = RateItem("a", 1200)
+    assert bucket.put(item) is False
+    assert bucket._last_wait is None
+
+    assert bucket.waiting(item) == legacy_waiting(bucket, item)
+    assert bucket.waiting(item) == 1000 + 1000 - 1200 + 1
+
+
+def test_put_decision_reports_unknown_wait_for_a_legacy_bucket():
+    bucket = LegacyBucket([Rate(1, 1000)])
+    assert bucket.put(RateItem("a", 1000)) is True
+
+    decision = bucket.put_decision(RateItem("a", 1200))
+    assert isinstance(decision, Decision)
+    assert not decision.allowed
+    assert decision.retry_after_ms is None  # "ask waiting()", not "no wait"
+    assert bucket.waiting(RateItem("a", 1200)) == 801

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -281,3 +281,56 @@ def test_put_decision_reports_unknown_wait_for_a_legacy_bucket():
     assert not decision.allowed
     assert decision.retry_after_ms is None  # "ask waiting()", not "no wait"
     assert bucket.waiting(RateItem("a", 1200)) == 801
+
+
+# ------------------------------------------------------- redis lua sentinels
+
+class StubRedis:
+    """Returns a canned `evalsha` reply, to pin the sentinel mapping."""
+
+    def __init__(self, reply):
+        self.reply = reply
+
+    def evalsha(self, *_args, **_kwargs):
+        return self.reply
+
+
+def _redis_bucket(reply, rates):
+    from pyrate_limiter import RedisBucket
+
+    return RedisBucket(rates, StubRedis(reply), "stub-key", "stub-hash")
+
+
+def test_redis_sentinel_never_fits():
+    rates = [Rate(3, 1000)]
+    bucket = _redis_bucket([0, -1], rates)
+
+    item = RateItem("a", 1000, weight=9)
+    assert bucket.put(item) is False
+    assert bucket.failing_rate is rates[0]
+    assert bucket._last_wait is None
+    assert bucket.waiting(item) == -1
+
+
+def test_redis_sentinel_no_blocking_item():
+    """-2 must not read as "never fits": it means already ready, wait 0."""
+    rates = [Rate(3, 1000)]
+    bucket = _redis_bucket([0, -2], rates)
+
+    item = RateItem("a", 1000, weight=1)
+    assert bucket.put(item) is False
+    assert bucket.failing_rate is rates[0]
+    assert bucket.waiting(item) == 0
+
+    decision = bucket.put_decision(RateItem("a", 1000, weight=1))
+    assert isinstance(decision, Decision)
+    assert decision.retry_after_ms == 0
+
+
+def test_redis_blocking_timestamp_becomes_a_wait():
+    rates = [Rate(3, 1000)]
+    bucket = _redis_bucket([0, 700], rates)
+
+    item = RateItem("a", 1200, weight=1)
+    assert bucket.put(item) is False
+    assert bucket.waiting(item) == 700 + 1000 - 1200 + 1

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -1,10 +1,4 @@
-"""Retry-after carried on `Decision` (Phase A).
-
-`put()` now records the wait alongside the verdict, so `waiting()` can answer
-without a second lookup into storage. These tests pin the recorded value to the
-pre-4.5 derivation it replaces, check that the fallback still works for buckets
-that record nothing, and cover the cases where a recorded wait must be ignored.
-"""
+"""Retry-after carried on `Decision`: recorded by put(), read by waiting()."""
 from typing import List, Optional
 
 import pytest
@@ -14,12 +8,7 @@ from pyrate_limiter.abstracts.algorithm import ADMITTED, SlidingWindowLog
 
 
 def legacy_waiting(bucket, item: RateItem) -> int:
-    """The pre-4.5 derivation of the wait, kept here as the reference.
-
-    Looks up the item that must expire first and measures it against the
-    window's inclusive lower bound. `waiting()` no longer computes this on the
-    happy path, so it is reproduced verbatim to cross-check what put() records.
-    """
+    """The pre-4.5 derivation, kept as the reference to cross-check against."""
     rate = bucket.failing_rate
 
     if rate is None:
@@ -58,8 +47,6 @@ def test_decision_carries_retry_after():
 def test_blocking_offset_and_retry_after():
     algo = SlidingWindowLog()
     rate = Rate(5, 1000)
-    # Freeing room for `weight` means waiting on the item `limit - weight`
-    # places from the newest.
     assert algo.blocking_offset(rate, 1) == 4
     assert algo.blocking_offset(rate, 5) == 0
     # +1 clears the inclusive lower bound.
@@ -87,7 +74,7 @@ def test_decide_skips_lookup_when_weight_can_never_fit():
 
     decision = algo.decide(rates, [0], weight=4, now=1000, peek_timestamp=boom)
     assert not decision.allowed
-    # None, not 0: waiting() reports -1 for a weight that exceeds the limit.
+    # None, not 0: waiting() reports -1 for a weight over the limit.
     assert decision.retry_after_ms is None
 
 
@@ -169,15 +156,14 @@ def test_recorded_wait_is_not_reused_for_a_different_weight():
     assert bucket.put(light) is False
     assert bucket.waiting(light) == 1000 + 1000 - 1300 + 1  # 701
 
-    # A heavier item must wait on a *different* stored item, so the recording
-    # made for weight 1 has to be ignored rather than reused.
+    # A heavier item waits on a different stored item.
     heavy = RateItem("a", 1300, weight=2)
     assert bucket.waiting(heavy) == 1100 + 1000 - 1300 + 1  # 801
     assert bucket.waiting(heavy) == legacy_waiting(bucket, heavy)
 
 
 def test_recorded_wait_survives_a_later_query_timestamp():
-    """The recording is an absolute instant, so a later query shrinks the wait."""
+    """Recorded as an absolute instant, so a later query shrinks the wait."""
     bucket = InMemoryBucket([Rate(1, 1000)])
     assert bucket.put(RateItem("a", 1000)) is True
 
@@ -232,11 +218,22 @@ def test_put_decision_for_a_weightless_item():
     assert bucket.put(RateItem("a", 1000)) is True
     assert bucket.put(RateItem("a", 1000)) is False
 
-    # A weightless item is always admitted, so it must not inherit the standing
-    # denial left behind by the previous put.
     decision = bucket.put_decision(RateItem("a", 1000, weight=0))
     assert isinstance(decision, Decision)
     assert decision.allowed
+
+
+def test_weightless_put_clears_a_standing_denial():
+    """A trivial admit still records: the previous denial must not survive it."""
+    bucket = InMemoryBucket([Rate(1, 1000)])
+    assert bucket.put(RateItem("a", 1000)) is True
+    assert bucket.put(RateItem("a", 1000)) is False
+    assert bucket.failing_rate is not None
+    assert bucket._last_wait is not None
+
+    assert bucket.put(RateItem("a", 1000, weight=0)) is True
+    assert bucket.failing_rate is None
+    assert bucket._last_wait is None
 
 
 def test_put_decision_reports_no_wait_for_an_impossible_weight():
@@ -254,12 +251,10 @@ def test_put_decision_reports_no_wait_for_an_impossible_weight():
 # ------------------------------------------------- fallback for custom buckets
 
 class LegacyBucket(InMemoryBucket):
-    """A bucket written against the pre-4.5 contract: sets `failing_rate` on
-    denial and records no retry-after."""
+    """Pre-4.5 contract: sets `failing_rate`, records no retry-after."""
 
     def put(self, item: RateItem) -> bool:
         admitted = super().put(item)
-        # Drop the recording, keeping only the old side-channel.
         self._last_wait = None
         return admitted
 


### PR DESCRIPTION
Groundwork for pluggable algorithms. Additive — no breaking public API changes.

## Why

`Decision` carried only the verdict, so the wait was derived separately by `AbstractBucket.waiting()` — looking up the k-th-newest stored item and measuring it against the window bound. Two consequences:

1. **A second round trip and a race on every rate-limited request.** `put()` decided, released its lock, and then `waiting()` went back to storage. On Redis that is a whole extra `ZRANGE` over a sorted set that may have changed since the put; on Postgres a query outside the `EXCLUSIVE` lock the check was made under.
2. **It only works for log-shaped storage.** A token bucket or GCRA has no k-th-newest item to peek at — its wait is a closed form over one or two scalars. Retry-after has to travel on `Decision` before any of those can exist.

## What changed

**`Decision.retry_after_ms`**, recorded by `put()`. `waiting()` reads the recording; it keeps its signature and falls back to the previous peek-based derivation when a bucket records nothing, so custom backends written against the pre-4.5 contract are unaffected.

**`LogAlgorithm` split out of `Algorithm`.** `leak_bound()` plus the new `blocking_offset()` / `retry_after()` live there — the sub-interface for policies whose state is a log of timestamped items. Constant-state policies won't implement it. `LogAlgorithm.decide()` does admit-and-resolve in one step and only touches storage on the deny path.

**Every backend now resolves the wait inside the same lock as the verdict:**

| Backend | Before | After |
|---|---|---|
| Redis | Lua returns rate index; separate `ZRANGE` from `waiting()` | Lua returns `{idx, blocking_ts}` — one atomic call |
| Postgres | `PEEK` after the `EXCLUSIVE` lock was released | inside the locked transaction |
| SQLite | `PEEK` in a second `self.lock` acquisition | inside `put()`'s existing hold |
| InMemory / Multiprocess | second scan via `peek()` | falls out of the bisect `put()` already did |

**`AbstractBucket.put_decision()`** returns the full `Decision`, so verdict and wait arrive together instead of via the `failing_rate` attribute plus a follow-up `waiting()`. Default implementation reads back what `put()` recorded — no bucket needs to override it.

**Bug fix:** `SQLiteBucket` never cleared `failing_rate` on a successful put. Every other backend did. Not reachable through `Limiter` today, but it would have been through `put_decision()`.

The inclusive-window `+1` correction now lives in exactly one place, `SlidingWindowLog.retry_after`, rather than inlined in `waiting()`. To be clear, it is not eliminated — it is inherent to a discrete inclusive window; only a closed-form algorithm escapes it.

`Algorithm`, `LogAlgorithm`, `Decision` and `SlidingWindowLog` are now exported from the package root.

## Testing

- **250 tests, 249 passed, 1 skipped** across all 7 backends (in-memory, sqlite, filelock-sqlite, multiprocess, redis, async-redis, postgres) against live Redis and Postgres. The skip is pre-existing (`test_limiter.py:226`, mpbucket timing).
- **29 new tests** in `tests/test_retry_after.py`, including a parametrized sweep asserting the recorded wait equals the old derivation across 4 rate configurations × 3 weights, plus coverage for weight mismatch, impossible weights, later query timestamps, and the legacy-bucket fallback.
- `test_bucket_records_retry_after` added to the shared bucket suite, so all 7 backends assert the recording matches deriving from storage.
- ruff and mypy clean.

Two notes on the run: `test_bucket_flush` failed once under `-n 4`, but it flakes on `master` too (baseline needed 2 reruns of the same test) — it is a timing loop that admits more than 50 items when the CPU is contended. The un-awaited-coroutine warning in `test_limiter_decorator[async_redis]` is pre-existing, with an identical count on `master`; it just names a different coroutine in the chain.

## Follow-ups (not in this PR)

- **Phase B** — an `Algorithm.windows()` hook, unlocking `FixedWindow` and `SlidingWindowCounter` on the existing log storage with only a bounds change.
- **Phase C** — a `StateStore` seam and GCRA (with `TokenBucket` as a preset over it), which this PR unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFX7N6Da9R5wV7viZzbwZa
