### PR TITLE
fix: close buckets in BucketFactory.close()

### DIFF
--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -429,8 +429,18 @@ class BucketFactory(ABC):
             except Exception as e:
                 logger.debug("Exception %s (%s) deleting bucket %r", type(e).__name__, e, bucket)
 
+    def owned_buckets(self) -> List[AbstractBucket]:
+        """Buckets this factory is responsible for releasing on ``close()``.
+
+        Deliberately distinct from ``get_buckets()``, which reports what the
+        Leaker currently tracks. A bucket can be owned and in use while absent
+        from that registry and it still needs closing. Subclasses that retain
+        buckets of their own should extend this.
+        """
+        return self.get_buckets()
+
     def close(self) -> None:
-        buckets = self.get_buckets()
+        buckets = self.owned_buckets()
 
         try:
             if self._leaker is not None:

--- a/pyrate_limiter/abstracts/bucket.py
+++ b/pyrate_limiter/abstracts/bucket.py
@@ -430,6 +430,8 @@ class BucketFactory(ABC):
                 logger.debug("Exception %s (%s) deleting bucket %r", type(e).__name__, e, bucket)
 
     def close(self) -> None:
+        buckets = self.get_buckets()
+
         try:
             if self._leaker is not None:
                 self._leaker.close()
@@ -437,7 +439,7 @@ class BucketFactory(ABC):
         except Exception as e:
             logger.info("Exception %s (%s) deleting bucket %r", type(e).__name__, e, self._leaker)
 
-        for bucket in self.get_buckets():
+        for bucket in buckets:
             try:
                 logger.debug("Closing bucket %s", bucket)
                 bucket.close()

--- a/pyrate_limiter/limiter.py
+++ b/pyrate_limiter/limiter.py
@@ -58,6 +58,18 @@ class SingleBucketFactory(BucketFactory):
     def get(self, _: RateItem) -> AbstractBucket:
         return self.bucket
 
+    def owned_buckets(self) -> List[AbstractBucket]:
+        """This factory holds ``self.bucket`` for its whole life, so it must be
+        closed even when it was never registered for leaking
+        (``schedule_leak=False``) or has since been disposed.
+        """
+        buckets = super().owned_buckets()
+
+        if all(bucket is not self.bucket for bucket in buckets):
+            buckets.append(self.bucket)
+
+        return buckets
+
 
 @contextmanager
 def combined_lock(locks: Union[Iterable[LockLike], RLock], blocking: bool, timeout: int | float = -1):

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -1,6 +1,7 @@
 import pytest
 from .conftest import DEFAULT_RATES
 from pyrate_limiter import Limiter
+from pyrate_limiter import SingleBucketFactory
 
 @pytest.mark.asyncio
 async def test_multiple_bucket_closes(
@@ -34,6 +35,29 @@ async def test_limiter_close_closes_its_buckets(
     limiter.close()
 
     assert calls, "Limiter.close() must close the buckets it owns"
+
+
+@pytest.mark.asyncio
+async def test_limiter_close_closes_bucket_without_scheduled_leak(
+    create_bucket,
+):
+    # Makes sure the limiter closes its bucket even when no leak was scheduled
+
+    bucket = await create_bucket(DEFAULT_RATES)
+
+    calls = []
+    real_close = bucket.close
+
+    def spy():
+        calls.append(bucket)
+        real_close()
+
+    bucket.close = spy
+
+    limiter = Limiter(SingleBucketFactory(bucket, schedule_leak=False))
+    limiter.close()
+
+    assert calls, "Limiter.close() must close its bucket even without a leaker"
 
 
 @pytest.mark.asyncio

--- a/tests/test_closing.py
+++ b/tests/test_closing.py
@@ -14,6 +14,29 @@ async def test_multiple_bucket_closes(
 
 
 @pytest.mark.asyncio
+async def test_limiter_close_closes_its_buckets(
+    create_bucket,
+):
+    # Makes sure closing the limiter closes the buckets it owns
+
+    bucket = await create_bucket(DEFAULT_RATES)
+
+    calls = []
+    real_close = bucket.close
+
+    def spy():
+        calls.append(bucket)
+        real_close()
+
+    bucket.close = spy
+
+    limiter = Limiter(bucket)
+    limiter.close()
+
+    assert calls, "Limiter.close() must close the buckets it owns"
+
+
+@pytest.mark.asyncio
 async def test_multiple_bucket_closes_limiter(
     create_bucket,
 ):


### PR DESCRIPTION
BucketFactory.close() tears down the leaker and then loops over self.get_buckets() to close each bucket. But get_buckets() reads the buckets off self._leaker, and by that point _leaker is None (and its registries were cleared by Leaker.close() anyway). So the loop always iterates an empty list and bucket.close() is never called.

Since `Limiter.close()` and `Limiter.__exit__` both delegate here, this means the documented cleanup path does nothing:

```python
bucket = SQLiteBucket.init_from_file([Rate(3, Duration.SECOND)], table="t1")
limiter = Limiter(bucket)
limiter.try_acquire("x")
limiter.close()

print(bucket.conn)  # <sqlite3.Connection object at 0x...> - still open
```

Worst case is PostgresBucket, where close() shuts down the entire ConnectionPool. Long-lived processes that create limiters per tenant or per key will accumulate pools and SQLite handles indefinitely.

This fix involves taking the snapshot before tearing the leaker down, then iterating that. I've also added a test that wraps bucket.close with a spy and asserts the limiter triggers it.